### PR TITLE
feat: bound MCP responses and add cursor pagination (houdini-mcp-2t6)

### DIFF
--- a/houdini_mcp/server.py
+++ b/houdini_mcp/server.py
@@ -10,6 +10,7 @@ from starlette.responses import JSONResponse
 
 from . import tools
 from .connection import ensure_connected, get_connection_info, is_connected, ping
+from .tools._common import apply_response_cap
 
 # Configure logging
 log_level = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -140,18 +141,20 @@ def execute_code(
         if output exceeded size limits.
         If dangerous patterns detected and not allowed, returns error with detected patterns.
     """
-    return tools.execute_code(
-        code=code,
-        capture_diff=capture_diff,
-        max_stdout_size=max_stdout_size,
-        max_stderr_size=max_stderr_size,
-        max_diff_nodes=max_diff_nodes,
-        timeout=timeout,
-        allow_dangerous=allow_dangerous,
-        allow_heavy_geometry=allow_heavy_geometry,
-        policy=policy,
-        host=HOUDINI_HOST,
-        port=HOUDINI_PORT,
+    return apply_response_cap(
+        tools.execute_code(
+            code=code,
+            capture_diff=capture_diff,
+            max_stdout_size=max_stdout_size,
+            max_stderr_size=max_stderr_size,
+            max_diff_nodes=max_diff_nodes,
+            timeout=timeout,
+            allow_dangerous=allow_dangerous,
+            allow_heavy_geometry=allow_heavy_geometry,
+            policy=policy,
+            host=HOUDINI_HOST,
+            port=HOUDINI_PORT,
+        )
     )
 
 

--- a/houdini_mcp/server.py
+++ b/houdini_mcp/server.py
@@ -329,6 +329,8 @@ def list_node_types(
     max_results: int = 100,
     name_filter: str | None = None,
     offset: int = 0,
+    limit: int | None = None,
+    cursor: int | None = None,
 ) -> dict[str, Any]:
     """
     List available Houdini node types.
@@ -354,7 +356,14 @@ def list_node_types(
         list_node_types(category="Sop", offset=100)  # Get next page of SOPs
     """
     return tools.list_node_types(
-        category, max_results, name_filter, offset, HOUDINI_HOST, HOUDINI_PORT
+        category=category,
+        max_results=max_results,
+        name_filter=name_filter,
+        offset=offset,
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        limit=limit,
+        cursor=cursor,
     )
 
 
@@ -365,6 +374,8 @@ def list_children(
     max_depth: int = 10,
     max_nodes: int = 1000,
     compact: bool = False,
+    limit: int = 20,
+    cursor: int | None = None,
 ) -> dict[str, Any]:
     """
     List child nodes with paths, types, and current input connections.
@@ -394,7 +405,15 @@ def list_children(
         list_children("/obj/geo1", compact=True)  # Minimal payload
     """
     return tools.list_children(
-        node_path, recursive, max_depth, max_nodes, compact, HOUDINI_HOST, HOUDINI_PORT
+        node_path=node_path,
+        recursive=recursive,
+        max_depth=max_depth,
+        max_nodes=max_nodes,
+        compact=compact,
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        limit=limit,
+        cursor=cursor,
     )
 
 
@@ -405,6 +424,8 @@ def find_nodes(
     node_type: str | None = None,
     max_results: int = 100,
     offset: int = 0,
+    limit: int | None = None,
+    cursor: int | None = None,
 ) -> dict[str, Any]:
     """
     Find nodes by name pattern or type using glob/substring matching.
@@ -431,7 +452,15 @@ def find_nodes(
         find_nodes("/obj", "*", offset=100) - Get next page of results
     """
     return tools.find_nodes(
-        root_path, pattern, node_type, max_results, offset, HOUDINI_HOST, HOUDINI_PORT
+        root_path=root_path,
+        pattern=pattern,
+        node_type=node_type,
+        max_results=max_results,
+        offset=offset,
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        limit=limit,
+        cursor=cursor,
     )
 
 
@@ -900,7 +929,7 @@ def get_parameter_schema(
 @mcp.tool()
 async def get_geo_summary(
     node_path: str,
-    max_sample_points: int = 100,
+    max_sample_points: int = 16,
     include_attributes: bool = True,
     include_groups: bool = True,
     summarize: bool = False,
@@ -914,7 +943,7 @@ async def get_geo_summary(
 
     Args:
         node_path: Full path to the SOP node (e.g., "/obj/geo1/sphere1")
-        max_sample_points: Maximum number of sample points to return (default: 100, max: 10000).
+        max_sample_points: Maximum number of sample points to return (default: 16, max: 10000).
                           Set to 0 to skip point sampling.
         include_attributes: Whether to include attribute metadata (default: True)
         include_groups: Whether to include group information (default: True)

--- a/houdini_mcp/server.py
+++ b/houdini_mcp/server.py
@@ -738,7 +738,7 @@ async def find_error_nodes(
     if summarize or (result.get("error_count", 0) > 5):
         result = await tools.summarize_errors(result)
 
-    return result
+    return apply_response_cap(result)
 
 
 @mcp.tool()
@@ -988,7 +988,7 @@ async def get_geo_summary(
     if summarize or tools.should_summarize(result):
         result = await tools.summarize_geometry(result)
 
-    return result
+    return apply_response_cap(result)
 
 
 @mcp.tool()

--- a/houdini_mcp/server.py
+++ b/houdini_mcp/server.py
@@ -731,7 +731,12 @@ async def find_error_nodes(
         find_error_nodes(summarize=True)  # Get AI triage of errors
     """
     result = tools.find_error_nodes(
-        root_path, include_warnings, max_results, HOUDINI_HOST, HOUDINI_PORT
+        root_path,
+        include_warnings,
+        max_results,
+        HOUDINI_HOST,
+        HOUDINI_PORT,
+        _defer_cap=True,
     )
 
     # Apply AI summarization if requested or if many errors found
@@ -981,7 +986,13 @@ async def get_geo_summary(
         get_geo_summary("/obj/geo1/noise1", max_sample_points=200, summarize=True)
     """
     result = tools.get_geo_summary(
-        node_path, max_sample_points, include_attributes, include_groups, HOUDINI_HOST, HOUDINI_PORT
+        node_path,
+        max_sample_points,
+        include_attributes,
+        include_groups,
+        HOUDINI_HOST,
+        HOUDINI_PORT,
+        _defer_cap=True,
     )
 
     # Apply AI summarization if requested or if response is very large

--- a/houdini_mcp/tools/_common.py
+++ b/houdini_mcp/tools/_common.py
@@ -1062,7 +1062,10 @@ def paginate_list(
         result = paginate_list(nodes, limit=10, cursor=0)
         # Returns first 10 nodes with cursor=10 if more exist
     """
-    offset = cursor if cursor is not None else 0
+    # Clamp invalid inputs so callers cannot receive a repeating cursor (for
+    # example limit=0, cursor=0 forever) or negative Python-slice semantics.
+    limit = max(1, int(limit))
+    offset = max(0, int(cursor)) if cursor is not None else 0
     total = len(items)
 
     # Slice the page

--- a/houdini_mcp/tools/_common.py
+++ b/houdini_mcp/tools/_common.py
@@ -1175,6 +1175,8 @@ def apply_response_cap(
         ("sample_points", "sample_point"),
         ("attributes", "attribute"),
         ("groups", "group"),
+        ("error_nodes", "error_node"),
+        ("warning_nodes", "warning_node"),
     ]
 
     for field_name, _singular_name in data_fields:
@@ -1206,7 +1208,11 @@ def apply_response_cap(
             while low <= high:
                 midpoint = (low + high) // 2
                 try:
-                    if _serialized_size(prefix_candidate(midpoint)) <= max_bytes:
+                    # Reserve room for pagination/truncation metadata added
+                    # after the prefix is selected.
+                    if _serialized_size(prefix_candidate(midpoint)) <= max_bytes - min(
+                        512, max_bytes // 4
+                    ):
                         best = midpoint
                         low = midpoint + 1
                     else:
@@ -1219,17 +1225,44 @@ def apply_response_cap(
                 result[f"{field_name}_truncated"] = True
                 result[f"{field_name}_original_count"] = len(field_value)
                 result[f"{field_name}_preserved_count"] = best
+                # If this list is a paginated payload, continuation must start
+                # after what was actually returned, not after the pre-cap page.
+                if field_name in {"items", "children", "matches", "node_types"}:
+                    current_offset = int(data.get("offset", 0))
+                    result["returned"] = best
+                    result["count"] = best
+                    result["has_more"] = True
+                    result["cursor"] = current_offset + best
+                    result["next_offset"] = current_offset + best
         elif isinstance(field_value, dict):
-            # Try to include the dict if it fits
-            try:
-                test_result = dict(result)
-                test_result[field_name] = field_value
-                test_json = json.dumps(test_result, ensure_ascii=False)
-                test_size = len(test_json.encode("utf-8"))
-                if test_size <= max_bytes - 50:
-                    result[field_name] = field_value
-            except Exception:
-                pass
+            # Preserve bounded prefixes from nested geometry/category lists
+            # instead of dropping the entire requested diagnostic dictionary.
+            preserved_dict: dict[str, Any] = {}
+            category_counts: dict[str, dict[str, int]] = {}
+            for category, category_value in field_value.items():
+                if not isinstance(category_value, list):
+                    candidate_value = category_value
+                else:
+                    candidate_value = []
+                    for item in category_value:
+                        candidate = dict(result)
+                        nested = dict(preserved_dict)
+                        nested[category] = candidate_value + [item]
+                        candidate[field_name] = nested
+                        _set_final_serialized_size(candidate)
+                        if _serialized_size(candidate) <= max_bytes - min(512, max_bytes // 4):
+                            candidate_value.append(item)
+                        else:
+                            break
+                    category_counts[str(category)] = {
+                        "original": len(category_value),
+                        "preserved": len(candidate_value),
+                    }
+                preserved_dict[str(category)] = candidate_value
+            if any(value for value in preserved_dict.values()):
+                result[field_name] = preserved_dict
+                result[f"{field_name}_truncated"] = True
+                result[f"{field_name}_category_counts"] = category_counts
 
     # Add exact final size metadata (including the field itself).
     _set_final_serialized_size(result)
@@ -1257,8 +1290,18 @@ def apply_response_cap(
                 except Exception:
                     pass
 
-        # Add exact final size metadata for the minimal fallback too.
+        # Add exact final size metadata for the minimal fallback too. If that
+        # metadata crosses the cap, drop optional essentials from the end until
+        # the final object itself fits (a long error message is the common case).
         _set_final_serialized_size(minimal)
+        while _serialized_size(minimal) > max_bytes:
+            optional = [key for key in essential_fields if key in minimal and key != "status"]
+            if not optional:
+                minimal.pop("message", None)
+                _set_final_serialized_size(minimal)
+                break
+            minimal.pop(optional[-1], None)
+            _set_final_serialized_size(minimal)
 
         return minimal
 

--- a/houdini_mcp/tools/_common.py
+++ b/houdini_mcp/tools/_common.py
@@ -54,6 +54,11 @@ __all__ = [
     "RESPONSE_SIZE_LARGE_THRESHOLD",
     "_estimate_response_size",
     "_add_response_metadata",
+    # Response pagination and bounds (HDMCP-52 / houdini-mcp-2t6)
+    "paginate_list",
+    "apply_response_cap",
+    "apply_detail_mode",
+    "DEFAULT_RESPONSE_CAP_BYTES",
     # Serialization utilities
     "_json_safe_hou_value",
     "_node_to_dict",
@@ -488,6 +493,9 @@ def _truncate_output(output: str, max_size: int) -> tuple[str, bool]:
 # Response size thresholds (in bytes)
 RESPONSE_SIZE_WARNING_THRESHOLD = 100 * 1024  # 100KB - warn above this
 RESPONSE_SIZE_LARGE_THRESHOLD = 500 * 1024  # 500KB - considered large
+
+# Hard response cap for bounded responses (HDMCP-52 / houdini-mcp-2t6)
+DEFAULT_RESPONSE_CAP_BYTES = 16 * 1024  # 16KB default cap
 
 
 def _estimate_response_size(data: Any, _depth: int = 0) -> int:
@@ -979,3 +987,223 @@ async def run_in_executor(func: Any, *args: Any, **kwargs: Any) -> Any:
     loop = asyncio.get_event_loop()
     partial_func = functools.partial(func, *args, **kwargs)
     return await loop.run_in_executor(None, partial_func)
+
+
+# =============================================================================
+# Response Pagination and Bounds (HDMCP-52 / houdini-mcp-2t6)
+# =============================================================================
+
+
+def paginate_list(
+    items: list[Any],
+    limit: int = 20,
+    cursor: int | None = None,
+) -> dict[str, Any]:
+    """
+    Paginate a list with limit/cursor controls.
+
+    Args:
+        items: List to paginate
+        limit: Maximum items per page (default: 20)
+        cursor: Start offset for pagination (default: 0)
+
+    Returns:
+        Dict with:
+        - items: Page of items
+        - total: Total number of items
+        - returned: Number of items in this page
+        - has_more: Whether more pages exist
+        - cursor: Next cursor if has_more, otherwise omitted
+
+    Example:
+        result = paginate_list(nodes, limit=10, cursor=0)
+        # Returns first 10 nodes with cursor=10 if more exist
+    """
+    offset = cursor if cursor is not None else 0
+    total = len(items)
+
+    # Slice the page
+    page = items[offset : offset + limit]
+    returned = len(page)
+
+    # Check if more pages exist
+    has_more = (offset + returned) < total
+
+    result: dict[str, Any] = {
+        "items": page,
+        "total": total,
+        "returned": returned,
+        "has_more": has_more,
+    }
+
+    # Add cursor for next page if more exist
+    if has_more:
+        result["cursor"] = offset + returned
+
+    return result
+
+
+def apply_response_cap(
+    data: dict[str, Any],
+    max_bytes: int = DEFAULT_RESPONSE_CAP_BYTES,
+) -> dict[str, Any]:
+    """
+    Apply hard response size cap with JSON-safe truncation.
+
+    Ensures response never exceeds max_bytes after JSON serialization.
+    Truncated responses include metadata about original size and truncation.
+
+    Args:
+        data: Response dict to cap
+        max_bytes: Maximum bytes after JSON serialization
+
+    Returns:
+        Dict that serializes to <= max_bytes with truncation metadata if needed
+
+    Example:
+        result = apply_response_cap(large_response, max_bytes=16000)
+        # Result JSON is guaranteed <= 16KB
+    """
+    import json
+
+    # Serialize to measure size
+    try:
+        json_str = json.dumps(data, ensure_ascii=False)
+        json_bytes = json_str.encode("utf-8")
+        original_size = len(json_bytes)
+    except Exception:
+        # If can't serialize, return error metadata
+        return {
+            "status": "error",
+            "message": "Response serialization failed",
+            "_truncated": True,
+        }
+
+    # If under cap, return as-is
+    if original_size <= max_bytes:
+        return data
+
+    # Need to truncate - start with metadata
+    result = {
+        "_truncated": True,
+        "original_size_bytes": original_size,
+    }
+
+    # Preserve status if present
+    if "status" in data:
+        result["status"] = data["status"]
+
+    # Try to include as much of the original data as possible
+    # Iteratively truncate fields until we fit
+    truncated_data = dict(data)
+
+    # Remove large fields in order of size
+    field_sizes = []
+    for key, value in truncated_data.items():
+        try:
+            field_json = json.dumps({key: value}, ensure_ascii=False)
+            field_size = len(field_json.encode("utf-8"))
+            field_sizes.append((field_size, key))
+        except Exception:
+            field_sizes.append((0, key))
+
+    field_sizes.sort(reverse=True)
+
+    # Remove largest fields until we fit
+    for _size, key in field_sizes:
+        if key in ("status", "_truncated", "original_size_bytes", "truncated_size_bytes"):
+            continue  # Preserve metadata fields
+
+        current_size = len(json.dumps(result, ensure_ascii=False).encode("utf-8"))
+        if current_size <= max_bytes:
+            break
+
+        # Try to include a truncated version of this field
+        value = truncated_data[key]
+        if isinstance(value, list) and len(value) > 0:
+            # Truncate list to first few items
+            result[key] = value[: min(3, len(value))]
+            result[f"{key}_truncated"] = True
+            result[f"{key}_original_count"] = len(value)
+        elif isinstance(value, str) and len(value) > 100:
+            # Truncate string to first 100 chars
+            result[key] = value[:100] + "..."
+        elif key not in result:
+            # Skip this field entirely
+            pass
+
+    # Add final truncated size
+    final_json = json.dumps(result, ensure_ascii=False)
+    final_bytes = final_json.encode("utf-8")
+    result["truncated_size_bytes"] = len(final_bytes)
+
+    # Ensure we're actually under the cap
+    if len(final_bytes) > max_bytes:
+        # Fallback: return minimal response
+        minimal = {
+            "_truncated": True,
+            "original_size_bytes": original_size,
+            "message": f"Response too large ({original_size} bytes), truncated to fit {max_bytes} bytes",
+        }
+        if "status" in data:
+            minimal["status"] = data["status"]
+        return minimal
+
+    return result
+
+
+def apply_detail_mode(
+    data: dict[str, Any],
+    mode: str = "standard",
+) -> dict[str, Any]:
+    """
+    Apply detail level to response (compact/standard/detail).
+
+    Args:
+        data: Response dict
+        mode: Detail level - "compact", "standard", or "detail"
+
+    Returns:
+        Response dict filtered by detail level
+
+    Modes:
+        - compact: Essential fields only (path, type, counts)
+        - standard: Balanced (includes parameters, no metadata)
+        - detail: All fields including metadata
+    """
+    if mode == "detail":
+        # Return everything
+        return data
+
+    if mode == "standard":
+        # Return as-is for now (balanced default)
+        return data
+
+    if mode == "compact":
+        # Return minimal essential fields
+        compact = {}
+
+        # Always include these essential fields
+        essential_fields = ["status", "path", "type", "name", "node_path"]
+        for field in essential_fields:
+            if field in data:
+                compact[field] = data[field]
+
+        # Include counts instead of full arrays
+        if "children" in data and isinstance(data["children"], list):
+            compact["child_count"] = len(data["children"])
+        if "items" in data and isinstance(data["items"], list):
+            compact["item_count"] = len(data["items"])
+            compact["items"] = data["items"][:3]  # Sample
+        if "parameters" in data and isinstance(data["parameters"], dict):
+            compact["parameter_count"] = len(data["parameters"])
+
+        # Include pagination metadata
+        for field in ["total", "returned", "has_more", "cursor"]:
+            if field in data:
+                compact[field] = data[field]
+
+        return compact
+
+    # Unknown mode, return standard
+    return data

--- a/houdini_mcp/tools/_common.py
+++ b/houdini_mcp/tools/_common.py
@@ -546,6 +546,27 @@ def _estimate_response_size(data: Any, _depth: int = 0) -> int:
     return len(str(data)) + 2
 
 
+def _serialized_size(data: Any) -> int:
+    """Return the exact UTF-8 byte size used by MCP JSON serialization."""
+    import json
+
+    return len(json.dumps(data, ensure_ascii=False).encode("utf-8"))
+
+
+def _set_final_serialized_size(result: dict[str, Any]) -> None:
+    """Set self-referential size metadata to its exact fixed-point value."""
+    # The field's decimal digit count can change the size it reports. The value
+    # converges in a handful of iterations because only that digit count varies.
+    size = 0
+    for _ in range(8):
+        result["truncated_size_bytes"] = size
+        measured = _serialized_size(result)
+        if measured == size:
+            return
+        size = measured
+    result["truncated_size_bytes"] = _serialized_size(result)
+
+
 def _add_response_metadata(
     result: dict[str, Any],
     include_size: bool = True,
@@ -572,15 +593,18 @@ def _add_response_metadata(
             return apply_response_cap(result, max_bytes=max_bytes)
         return result
 
-    # First apply cap if requested (this becomes the response)
+    # Apply the cap to the payload first so oversized collections retain a
+    # useful bounded prefix plus continuation metadata.
     if apply_cap:
         result = apply_response_cap(result, max_bytes=max_bytes)
-        # If truncated, skip further size checks
         if result.get("_truncated"):
             return result
 
-    # Add size metadata for non-capped responses
-    size_bytes = _estimate_response_size(result)
+    # Add observability metadata for responses that did not require truncation.
+    # This metadata itself consumes bytes, so run the final object through the
+    # cap once more; otherwise a payload just below the boundary can become an
+    # over-cap response after `_response_size_bytes` is inserted.
+    size_bytes = _serialized_size(result)
     result["_response_size_bytes"] = size_bytes
 
     if size_bytes > RESPONSE_SIZE_LARGE_THRESHOLD:
@@ -591,7 +615,7 @@ def _add_response_metadata(
     elif size_bytes > RESPONSE_SIZE_WARNING_THRESHOLD:
         result["_response_size_note"] = f"Response size: {size_bytes // 1024}KB"
 
-    return result
+    return apply_response_cap(result, max_bytes=max_bytes) if apply_cap else result
 
 
 def _json_safe_hou_value(
@@ -1115,10 +1139,24 @@ def apply_response_cap(
 
     # Preserve essential metadata fields (small, informative)
     essential_fields = [
-        "node_path", "root_path", "path", "type", "name",
-        "total", "returned", "has_more", "cursor", "count",
-        "pattern", "category", "cook_state", "point_count",
-        "primitive_count", "vertex_count", "warning", "message"
+        "node_path",
+        "root_path",
+        "path",
+        "type",
+        "name",
+        "total",
+        "returned",
+        "has_more",
+        "cursor",
+        "count",
+        "pattern",
+        "category",
+        "cook_state",
+        "point_count",
+        "primitive_count",
+        "vertex_count",
+        "warning",
+        "message",
     ]
     for field in essential_fields:
         if field in data:
@@ -1143,27 +1181,41 @@ def apply_response_cap(
         field_value = data[field_name]
 
         if isinstance(field_value, list) and len(field_value) > 0:
-            # Try to fit as many items as possible within budget
-            preserved_items: list[Any] = []
-            for item in field_value:
+            # Find the longest useful prefix together with ALL truncation/size
+            # metadata. Serialized size is monotonic with prefix length, so a
+            # binary search avoids the old O(n²) repeated-growing-list cost on
+            # responses containing tens of thousands of items.
+            def prefix_candidate(
+                count: int,
+                *,
+                name: str = field_name,
+                values: list[Any] = field_value,
+            ) -> dict[str, Any]:
+                candidate = dict(result)
+                candidate[name] = values[:count]
+                candidate[f"{name}_truncated"] = True
+                candidate[f"{name}_original_count"] = len(values)
+                candidate[f"{name}_preserved_count"] = count
+                _set_final_serialized_size(candidate)
+                return candidate
+
+            low, high, best = 1, len(field_value), 0
+            while low <= high:
+                midpoint = (low + high) // 2
                 try:
-                    test_result = dict(result)
-                    test_result[field_name] = preserved_items + [item]
-                    test_json = json.dumps(test_result, ensure_ascii=False)
-                    test_size = len(test_json.encode("utf-8"))
-
-                    if test_size <= max_bytes - 50:  # Leave room for final metadata
-                        preserved_items.append(item)
+                    if _serialized_size(prefix_candidate(midpoint)) <= max_bytes:
+                        best = midpoint
+                        low = midpoint + 1
                     else:
-                        break
+                        high = midpoint - 1
                 except Exception:
-                    break
+                    high = midpoint - 1
 
-            if preserved_items:
-                result[field_name] = preserved_items
+            if best:
+                result[field_name] = field_value[:best]
                 result[f"{field_name}_truncated"] = True
                 result[f"{field_name}_original_count"] = len(field_value)
-                result[f"{field_name}_preserved_count"] = len(preserved_items)
+                result[f"{field_name}_preserved_count"] = best
         elif isinstance(field_value, dict):
             # Try to include the dict if it fits
             try:
@@ -1176,13 +1228,11 @@ def apply_response_cap(
             except Exception:
                 pass
 
-    # Add final truncated size with multibyte-safe encoding
-    final_json = json.dumps(result, ensure_ascii=False)
-    final_bytes = final_json.encode("utf-8")
-    result["truncated_size_bytes"] = len(final_bytes)
+    # Add exact final size metadata (including the field itself).
+    _set_final_serialized_size(result)
 
-    # Ensure we're actually under the cap
-    if len(final_bytes) > max_bytes:
+    # Ensure the final object, metadata included, is actually under the cap.
+    if _serialized_size(result) > max_bytes:
         # Need to be more aggressive - remove data fields and keep only metadata
         minimal = {
             "_truncated": True,
@@ -1204,9 +1254,8 @@ def apply_response_cap(
                 except Exception:
                     pass
 
-        # Add truncated_size_bytes for minimal fallback
-        minimal_json = json.dumps(minimal, ensure_ascii=False)
-        minimal["truncated_size_bytes"] = len(minimal_json.encode("utf-8"))
+        # Add exact final size metadata for the minimal fallback too.
+        _set_final_serialized_size(minimal)
 
         return minimal
 

--- a/houdini_mcp/tools/_common.py
+++ b/houdini_mcp/tools/_common.py
@@ -1151,6 +1151,7 @@ def apply_response_cap(
         "returned",
         "has_more",
         "cursor",
+        "next_offset",
         "count",
         "pattern",
         "category",

--- a/houdini_mcp/tools/_common.py
+++ b/houdini_mcp/tools/_common.py
@@ -57,7 +57,6 @@ __all__ = [
     # Response pagination and bounds (HDMCP-52 / houdini-mcp-2t6)
     "paginate_list",
     "apply_response_cap",
-    "apply_detail_mode",
     "DEFAULT_RESPONSE_CAP_BYTES",
     # Serialization utilities
     "_json_safe_hou_value",
@@ -547,20 +546,40 @@ def _estimate_response_size(data: Any, _depth: int = 0) -> int:
     return len(str(data)) + 2
 
 
-def _add_response_metadata(result: dict[str, Any], include_size: bool = True) -> dict[str, Any]:
+def _add_response_metadata(
+    result: dict[str, Any],
+    include_size: bool = True,
+    apply_cap: bool = True,
+    max_bytes: int = DEFAULT_RESPONSE_CAP_BYTES,
+) -> dict[str, Any]:
     """
-    Add response metadata including size information.
+    Add response metadata including size information and apply hard cap.
+
+    This is the single shared response finalization boundary for all production tools.
+    It ensures no response exceeds the configured cap after JSON serialization.
 
     Args:
         result: The result dictionary to augment
         include_size: Whether to include size metadata
+        apply_cap: Whether to apply hard response cap (default: True)
+        max_bytes: Maximum bytes after JSON serialization (default: DEFAULT_RESPONSE_CAP_BYTES)
 
     Returns:
-        The result dictionary with added metadata
+        The result dictionary with added metadata and applied cap
     """
     if not include_size:
+        if apply_cap:
+            return apply_response_cap(result, max_bytes=max_bytes)
         return result
 
+    # First apply cap if requested (this becomes the response)
+    if apply_cap:
+        result = apply_response_cap(result, max_bytes=max_bytes)
+        # If truncated, skip further size checks
+        if result.get("_truncated"):
+            return result
+
+    # Add size metadata for non-capped responses
     size_bytes = _estimate_response_size(result)
     result["_response_size_bytes"] = size_bytes
 
@@ -1051,7 +1070,8 @@ def apply_response_cap(
     Apply hard response size cap with JSON-safe truncation.
 
     Ensures response never exceeds max_bytes after JSON serialization.
-    Truncated responses include metadata about original size and truncation.
+    Truncated responses retain a useful bounded prefix/page plus continuation
+    and truncation metadata, not just metadata-only.
 
     Args:
         data: Response dict to cap
@@ -1062,7 +1082,7 @@ def apply_response_cap(
 
     Example:
         result = apply_response_cap(large_response, max_bytes=16000)
-        # Result JSON is guaranteed <= 16KB
+        # Result JSON is guaranteed <= 16KB, preserves useful data
     """
     import json
 
@@ -1083,8 +1103,8 @@ def apply_response_cap(
     if original_size <= max_bytes:
         return data
 
-    # Need to truncate - start with metadata
-    result = {
+    # Need to truncate - preserve status and essential fields first
+    result: dict[str, Any] = {
         "_truncated": True,
         "original_size_bytes": original_size,
     }
@@ -1093,53 +1113,77 @@ def apply_response_cap(
     if "status" in data:
         result["status"] = data["status"]
 
-    # Try to include as much of the original data as possible
-    # Iteratively truncate fields until we fit
-    truncated_data = dict(data)
+    # Preserve essential metadata fields (small, informative)
+    essential_fields = [
+        "node_path", "root_path", "path", "type", "name",
+        "total", "returned", "has_more", "cursor", "count",
+        "pattern", "category", "cook_state", "point_count",
+        "primitive_count", "vertex_count", "warning", "message"
+    ]
+    for field in essential_fields:
+        if field in data:
+            result[field] = data[field]
 
-    # Remove large fields in order of size
-    field_sizes = []
-    for key, value in truncated_data.items():
-        try:
-            field_json = json.dumps({key: value}, ensure_ascii=False)
-            field_size = len(field_json.encode("utf-8"))
-            field_sizes.append((field_size, key))
-        except Exception:
-            field_sizes.append((0, key))
+    # Try to preserve data fields (arrays, nested objects) within budget
+    data_fields = [
+        ("items", "item"),
+        ("children", "child"),
+        ("matches", "match"),
+        ("node_types", "node_type"),
+        ("parameters", "parameter"),
+        ("sample_points", "sample_point"),
+        ("attributes", "attribute"),
+        ("groups", "group"),
+    ]
 
-    field_sizes.sort(reverse=True)
+    for field_name, _singular_name in data_fields:
+        if field_name not in data:
+            continue
 
-    # Remove largest fields until we fit
-    for _size, key in field_sizes:
-        if key in ("status", "_truncated", "original_size_bytes", "truncated_size_bytes"):
-            continue  # Preserve metadata fields
+        field_value = data[field_name]
 
-        current_size = len(json.dumps(result, ensure_ascii=False).encode("utf-8"))
-        if current_size <= max_bytes:
-            break
+        if isinstance(field_value, list) and len(field_value) > 0:
+            # Try to fit as many items as possible within budget
+            preserved_items: list[Any] = []
+            for item in field_value:
+                try:
+                    test_result = dict(result)
+                    test_result[field_name] = preserved_items + [item]
+                    test_json = json.dumps(test_result, ensure_ascii=False)
+                    test_size = len(test_json.encode("utf-8"))
 
-        # Try to include a truncated version of this field
-        value = truncated_data[key]
-        if isinstance(value, list) and len(value) > 0:
-            # Truncate list to first few items
-            result[key] = value[: min(3, len(value))]
-            result[f"{key}_truncated"] = True
-            result[f"{key}_original_count"] = len(value)
-        elif isinstance(value, str) and len(value) > 100:
-            # Truncate string to first 100 chars
-            result[key] = value[:100] + "..."
-        elif key not in result:
-            # Skip this field entirely
-            pass
+                    if test_size <= max_bytes - 50:  # Leave room for final metadata
+                        preserved_items.append(item)
+                    else:
+                        break
+                except Exception:
+                    break
 
-    # Add final truncated size
+            if preserved_items:
+                result[field_name] = preserved_items
+                result[f"{field_name}_truncated"] = True
+                result[f"{field_name}_original_count"] = len(field_value)
+                result[f"{field_name}_preserved_count"] = len(preserved_items)
+        elif isinstance(field_value, dict):
+            # Try to include the dict if it fits
+            try:
+                test_result = dict(result)
+                test_result[field_name] = field_value
+                test_json = json.dumps(test_result, ensure_ascii=False)
+                test_size = len(test_json.encode("utf-8"))
+                if test_size <= max_bytes - 50:
+                    result[field_name] = field_value
+            except Exception:
+                pass
+
+    # Add final truncated size with multibyte-safe encoding
     final_json = json.dumps(result, ensure_ascii=False)
     final_bytes = final_json.encode("utf-8")
     result["truncated_size_bytes"] = len(final_bytes)
 
     # Ensure we're actually under the cap
     if len(final_bytes) > max_bytes:
-        # Fallback: return minimal response
+        # Need to be more aggressive - remove data fields and keep only metadata
         minimal = {
             "_truncated": True,
             "original_size_bytes": original_size,
@@ -1147,63 +1191,29 @@ def apply_response_cap(
         }
         if "status" in data:
             minimal["status"] = data["status"]
+
+        # Try to preserve essential fields
+        for field in essential_fields:
+            if field in data:
+                try:
+                    test_minimal = dict(minimal)
+                    test_minimal[field] = data[field]
+                    test_json = json.dumps(test_minimal, ensure_ascii=False)
+                    if len(test_json.encode("utf-8")) <= max_bytes:
+                        minimal[field] = data[field]
+                except Exception:
+                    pass
+
+        # Add truncated_size_bytes for minimal fallback
+        minimal_json = json.dumps(minimal, ensure_ascii=False)
+        minimal["truncated_size_bytes"] = len(minimal_json.encode("utf-8"))
+
         return minimal
 
     return result
 
 
-def apply_detail_mode(
-    data: dict[str, Any],
-    mode: str = "standard",
-) -> dict[str, Any]:
-    """
-    Apply detail level to response (compact/standard/detail).
-
-    Args:
-        data: Response dict
-        mode: Detail level - "compact", "standard", or "detail"
-
-    Returns:
-        Response dict filtered by detail level
-
-    Modes:
-        - compact: Essential fields only (path, type, counts)
-        - standard: Balanced (includes parameters, no metadata)
-        - detail: All fields including metadata
-    """
-    if mode == "detail":
-        # Return everything
-        return data
-
-    if mode == "standard":
-        # Return as-is for now (balanced default)
-        return data
-
-    if mode == "compact":
-        # Return minimal essential fields
-        compact = {}
-
-        # Always include these essential fields
-        essential_fields = ["status", "path", "type", "name", "node_path"]
-        for field in essential_fields:
-            if field in data:
-                compact[field] = data[field]
-
-        # Include counts instead of full arrays
-        if "children" in data and isinstance(data["children"], list):
-            compact["child_count"] = len(data["children"])
-        if "items" in data and isinstance(data["items"], list):
-            compact["item_count"] = len(data["items"])
-            compact["items"] = data["items"][:3]  # Sample
-        if "parameters" in data and isinstance(data["parameters"], dict):
-            compact["parameter_count"] = len(data["parameters"])
-
-        # Include pagination metadata
-        for field in ["total", "returned", "has_more", "cursor"]:
-            if field in data:
-                compact[field] = data[field]
-
-        return compact
-
-    # Unknown mode, return standard
-    return data
+# NOTE: apply_detail_mode was removed as it was not wired to production tools.
+# The PR scope is narrowed to focus on hard caps and pagination only.
+# Compact mode is available via the compact=True parameter on individual tools
+# (e.g., get_node_info, list_children) which directly control response verbosity.

--- a/houdini_mcp/tools/_common.py
+++ b/houdini_mcp/tools/_common.py
@@ -1159,12 +1159,27 @@ def apply_response_cap(
         "point_count",
         "primitive_count",
         "vertex_count",
+        "bounding_box",
+        "title",
+        "url",
         "warning",
         "message",
     ]
     for field in essential_fields:
         if field in data:
             result[field] = data[field]
+
+    # Preserve bounded textual payloads used by execute_code and help tools.
+    for field in ("stdout", "stderr", "traceback", "description"):
+        value = data.get(field)
+        if not isinstance(value, str) or not value:
+            continue
+        available = max(64, (max_bytes - _serialized_size(result)) // 2)
+        encoded = value.encode("utf-8")
+        if len(encoded) > available:
+            value = encoded[:available].decode("utf-8", errors="ignore") + "…"
+            result[f"{field}_truncated"] = True
+        result[field] = value
 
     # Try to preserve data fields (arrays, nested objects) within budget
     data_fields = [
@@ -1178,6 +1193,11 @@ def apply_response_cap(
         ("groups", "group"),
         ("error_nodes", "error_node"),
         ("warning_nodes", "warning_node"),
+        ("inputs", "input"),
+        ("outputs", "output"),
+        ("methods", "method"),
+        ("vex_info", "vex_item"),
+        ("scene_changes", "scene_change"),
     ]
 
     for field_name, _singular_name in data_fields:
@@ -1221,8 +1241,26 @@ def apply_response_cap(
                 except Exception:
                     high = midpoint - 1
 
+            if best == 0 and field_value:
+                # Preserve the identity/core shape of one oversized requested
+                # item by recursively capping it rather than dropping the field.
+                item = field_value[0]
+                if isinstance(item, dict):
+                    compact_item = apply_response_cap(item, max(256, max_bytes // 2))
+                elif isinstance(item, str):
+                    compact_item = item[: max(1, max_bytes // 8)] + "…"
+                else:
+                    compact_item = str(item)[: max(1, max_bytes // 8)]
+                candidate = prefix_candidate(1)
+                candidate[field_name] = [compact_item]
+                _set_final_serialized_size(candidate)
+                if _serialized_size(candidate) <= max_bytes:
+                    result.update(candidate)
+                    best = 1
+
             if best:
-                result[field_name] = field_value[:best]
+                if field_name not in result:
+                    result[field_name] = field_value[:best]
                 result[f"{field_name}_truncated"] = True
                 result[f"{field_name}_original_count"] = len(field_value)
                 result[f"{field_name}_preserved_count"] = best

--- a/houdini_mcp/tools/errors.py
+++ b/houdini_mcp/tools/errors.py
@@ -23,6 +23,8 @@ def find_error_nodes(
     max_results: int = 100,
     host: str = "localhost",
     port: int = 18811,
+    *,
+    _defer_cap: bool = False,
 ) -> dict[str, Any]:
     """
     Find all nodes with cook errors or warnings in the scene.
@@ -158,4 +160,4 @@ def find_error_nodes(
     if total_results >= max_results:
         result["warning"] = f"Results limited to {max_results}. Increase max_results to see more."
 
-    return _add_response_metadata(result)
+    return _add_response_metadata(result, apply_cap=not _defer_cap)

--- a/houdini_mcp/tools/geometry.py
+++ b/houdini_mcp/tools/geometry.py
@@ -19,7 +19,7 @@ logger = logging.getLogger("houdini_mcp.tools.geometry")
 @handle_connection_errors("get_geometry_summary")
 def get_geo_summary(
     node_path: str,
-    max_sample_points: int = 100,
+    max_sample_points: int = 16,
     include_attributes: bool = True,
     include_groups: bool = True,
     host: str = "localhost",
@@ -37,7 +37,9 @@ def get_geo_summary(
 
     Args:
         node_path: Path to the SOP node (e.g., "/obj/geo1/sphere1")
-        max_sample_points: Maximum number of sample points to return (default: 100, max: 10000)
+        max_sample_points: Maximum number of sample points to return (default: 16, max: 10000)
+            The default was reduced from 100 to 16 per HDMCP-52 (houdini-mcp-2t6)
+            to keep responses bounded. Use explicit sample_limit for more samples.
         include_attributes: Whether to include attribute metadata (default: True)
         include_groups: Whether to include group information (default: True)
 

--- a/houdini_mcp/tools/geometry.py
+++ b/houdini_mcp/tools/geometry.py
@@ -24,6 +24,8 @@ def get_geo_summary(
     include_groups: bool = True,
     host: str = "localhost",
     port: int = 18811,
+    *,
+    _defer_cap: bool = False,
 ) -> dict[str, Any]:
     """
     Get geometry statistics and metadata for verification.
@@ -244,7 +246,7 @@ print(json.dumps(result))
 
     try:
         result = json.loads(stdout)
-        return _add_response_metadata(result)
+        return _add_response_metadata(result, apply_cap=not _defer_cap)
     except json.JSONDecodeError as e:
         return {
             "status": "error",

--- a/houdini_mcp/tools/nodes.py
+++ b/houdini_mcp/tools/nodes.py
@@ -17,6 +17,7 @@ from ._common import (
     _json_safe_hou_value,
     ensure_connected,
     handle_connection_errors,
+    paginate_list,
 )
 from .cache import node_type_cache
 
@@ -344,11 +345,14 @@ def list_node_types(
         offset=offset,
     )
 
-    # Build result
+    # Build result with consistent pagination metadata (HDMCP-52)
     result: dict[str, Any] = {
         "status": "success",
-        "count": len(node_types),
         "node_types": node_types,
+        "count": len(node_types),  # Backward compat: count = returned
+        "total": total_matched,
+        "returned": len(node_types),
+        "has_more": has_more,
     }
 
     # Include category in result if filtered
@@ -358,13 +362,9 @@ def list_node_types(
         # Get available categories from cache
         result["categories_available"] = node_type_cache.get_categories(hou)
 
-    # Add pagination info
-    if offset > 0:
-        result["offset"] = offset
-
+    # Add cursor for next page
     if has_more:
-        result["has_more"] = True
-        result["next_offset"] = offset + len(node_types)
+        result["cursor"] = offset + len(node_types)
 
     # Add warning if results were limited
     if len(node_types) >= max_results and has_more:
@@ -391,6 +391,8 @@ def list_children(
     recursive: bool = False,
     max_depth: int = 10,
     max_nodes: int = 1000,
+    limit: int = 20,
+    cursor: int | None = None,
     compact: bool = False,
     host: str = "localhost",
     port: int = 18811,
@@ -401,16 +403,22 @@ def list_children(
     This tool is essential for agents to understand node networks and insert
     nodes without breaking existing connections.
 
+    Pagination (HDMCP-52 / houdini-mcp-2t6): Use limit/cursor for page-by-page
+    traversal. The default limit is 20 nodes per page.
+
     Args:
         node_path: Path to the parent node
         recursive: If True, recursively traverse child nodes
         max_depth: Maximum recursion depth (prevents infinite loops)
-        max_nodes: Maximum number of nodes to return (safety limit)
+        max_nodes: Maximum total nodes to collect (safety limit, default: 1000)
+        limit: Maximum nodes per page (default: 20)
+        cursor: Pagination cursor (offset) for next page
         compact: If True, return only path/name/type without connection details
 
     Returns:
         Dict with child nodes including their connection information.
         When compact=True, inputs/outputs are omitted for reduced payload size.
+        Includes pagination metadata: total, returned, has_more, cursor.
     """
     hou = ensure_connected(host, port)
 
@@ -497,15 +505,24 @@ def list_children(
 
     collect_children(parent)
 
+    # Apply pagination to collected children
+    paginated = paginate_list(children_list, limit=limit, cursor=cursor)
+
     result: dict[str, Any] = {
         "status": "success",
         "node_path": node_path,
-        "children": children_list,
-        "count": len(children_list),
+        "children": paginated["items"],
+        "count": paginated["returned"],  # Backward compat: count = returned
+        "total": paginated["total"],
+        "returned": paginated["returned"],
+        "has_more": paginated["has_more"],
     }
 
+    if paginated["has_more"]:
+        result["cursor"] = paginated["cursor"]
+
     if nodes_collected >= max_nodes:
-        result["warning"] = f"Result limited to {max_nodes} nodes"
+        result["warning"] = f"Collection limited to {max_nodes} nodes"
 
     # Add response size metadata for large responses
     return _add_response_metadata(result)
@@ -664,26 +681,30 @@ _result = {{"matches": matches, "total_matched": total_matched}}
 
         search_recursive(root)
 
+    # Calculate pagination metadata
+    has_more = total_matched > offset + len(matches)
+
     result: dict[str, Any] = {
         "status": "success",
         "root_path": root_path,
         "pattern": pattern,
         "matches": matches,
-        "count": len(matches),
+        "count": len(matches),  # Backward compat: count = returned
+        "total": total_matched,
+        "returned": len(matches),
+        "has_more": has_more,
     }
 
     if node_type:
         result["node_type_filter"] = node_type
 
-    # Add pagination info
+    # Add offset for backward compat
     if offset > 0:
         result["offset"] = offset
 
-    # Calculate if there are more results
-    has_more = total_matched > offset + len(matches)
+    # Add cursor for next page
     if has_more:
-        result["has_more"] = True
-        result["next_offset"] = offset + len(matches)
+        result["cursor"] = offset + len(matches)
 
     if len(matches) >= max_results:
         result["warning"] = (

--- a/houdini_mcp/tools/nodes.py
+++ b/houdini_mcp/tools/nodes.py
@@ -535,7 +535,7 @@ def list_children(
         "status": "success",
         "node_path": node_path,
         "children": paginated["items"],
-        "count": paginated["returned"],  # Backward compat: count = returned
+        "count": paginated["total"],  # Backward compat: count was total collected
         "total": paginated["total"],
         "returned": paginated["returned"],
         "has_more": paginated["has_more"],
@@ -607,9 +607,9 @@ def find_nodes(
     elif offset is None:
         offset = 0
 
-    # Validate offset
-    if offset < 0:
-        offset = 0
+    # Invalid aliases must not produce empty repeating pages.
+    max_results = max(1, min(int(max_results), 500))
+    offset = max(0, int(offset))
 
     # Execute search on Houdini side to minimize RPC overhead
     # Uses allSubChildren() which is much faster than recursive children() calls
@@ -662,9 +662,10 @@ if root is not None:
                 "type": child_type,
             }})
 
-            # Stop after one lookahead item; it proves another page exists.
+            # Keep counting exact totals after the page/lookahead is full, but
+            # stop materializing additional match records.
             if len(matches) >= fetch_limit:
-                break
+                continue
 
 _result = {{"matches": matches, "total_matched": total_matched}}
 """.format(
@@ -694,14 +695,9 @@ _result = {{"matches": matches, "total_matched": total_matched}}
 
         def search_recursive(node: Any) -> None:
             nonlocal total_matched
-            if len(matches) >= max_results + 1:
-                return
 
             try:
                 for child in node.children():
-                    if len(matches) >= max_results + 1:
-                        break
-
                     name_match = fnmatch_module.fnmatch(child.name().lower(), pattern.lower())
                     if "*" not in pattern and "?" not in pattern:
                         name_match = name_match or pattern.lower() in child.name().lower()
@@ -715,13 +711,14 @@ _result = {{"matches": matches, "total_matched": total_matched}}
                         if total_matched <= offset:
                             search_recursive(child)
                             continue
-                        matches.append(
-                            {
-                                "path": child.path(),
-                                "name": child.name(),
-                                "type": child.type().name(),
-                            }
-                        )
+                        if len(matches) < max_results + 1:
+                            matches.append(
+                                {
+                                    "path": child.path(),
+                                    "name": child.name(),
+                                    "type": child.type().name(),
+                                }
+                            )
                     search_recursive(child)
             except Exception as ex:
                 logger.debug(f"Could not search in {node.path()}: {ex}")

--- a/houdini_mcp/tools/nodes.py
+++ b/houdini_mcp/tools/nodes.py
@@ -294,10 +294,11 @@ def list_node_types(
     max_results: int | None = None,
     name_filter: str | None = None,
     offset: int | None = None,
-    limit: int | None = None,
-    cursor: int | None = None,
     host: str = "localhost",
     port: int = 18811,
+    *,
+    limit: int | None = None,
+    cursor: int | None = None,
 ) -> dict[str, Any]:
     """
     List available node types, optionally filtered by category.
@@ -381,9 +382,11 @@ def list_node_types(
         # Get available categories from cache
         result["categories_available"] = node_type_cache.get_categories(hou)
 
-    # Add cursor for next page
+    # Cursor is preferred; next_offset preserves the existing offset contract.
     if has_more:
-        result["cursor"] = offset + len(node_types)
+        next_page = offset + len(node_types)
+        result["cursor"] = next_page
+        result["next_offset"] = next_page
 
     # Add warning if results were limited
     if len(node_types) >= max_results and has_more:
@@ -410,11 +413,12 @@ def list_children(
     recursive: bool = False,
     max_depth: int = 10,
     max_nodes: int = 1000,
-    limit: int = 20,
-    cursor: int | None = None,
     compact: bool = False,
     host: str = "localhost",
     port: int = 18811,
+    *,
+    limit: int = 20,
+    cursor: int | None = None,
 ) -> dict[str, Any]:
     """
     List child nodes with paths, types, and current input connections.
@@ -539,6 +543,7 @@ def list_children(
 
     if paginated["has_more"]:
         result["cursor"] = paginated["cursor"]
+        result["next_offset"] = paginated["cursor"]
 
     if nodes_collected >= max_nodes:
         result["warning"] = f"Collection limited to {max_nodes} nodes"
@@ -554,10 +559,11 @@ def find_nodes(
     node_type: str | None = None,
     max_results: int | None = None,
     offset: int | None = None,
-    limit: int | None = None,
-    cursor: int | None = None,
     host: str = "localhost",
     port: int = 18811,
+    *,
+    limit: int | None = None,
+    cursor: int | None = None,
 ) -> dict[str, Any]:
     """
     Find nodes by name pattern or type using glob/substring matching.
@@ -615,6 +621,9 @@ pattern = "{pattern}"
 node_type_filter = {node_type_repr}
 max_results = {max_results}
 offset = {offset}
+# Fetch one extra match to determine has_more without scanning/materializing
+# the rest of a potentially huge network.
+fetch_limit = max_results + 1
 
 matches = []
 total_matched = 0
@@ -653,8 +662,8 @@ if root is not None:
                 "type": child_type,
             }})
 
-            # Stop if we have enough results
-            if len(matches) >= max_results:
+            # Stop after one lookahead item; it proves another page exists.
+            if len(matches) >= fetch_limit:
                 break
 
 _result = {{"matches": matches, "total_matched": total_matched}}
@@ -685,12 +694,12 @@ _result = {{"matches": matches, "total_matched": total_matched}}
 
         def search_recursive(node: Any) -> None:
             nonlocal total_matched
-            if len(matches) >= max_results:
+            if len(matches) >= max_results + 1:
                 return
 
             try:
                 for child in node.children():
-                    if len(matches) >= max_results:
+                    if len(matches) >= max_results + 1:
                         break
 
                     name_match = fnmatch_module.fnmatch(child.name().lower(), pattern.lower())
@@ -719,8 +728,10 @@ _result = {{"matches": matches, "total_matched": total_matched}}
 
         search_recursive(root)
 
-    # Calculate pagination metadata
-    has_more = total_matched > offset + len(matches)
+    # The extra lookahead item is never returned; it only proves another page.
+    has_more = len(matches) > max_results
+    if has_more:
+        matches = matches[:max_results]
 
     result: dict[str, Any] = {
         "status": "success",
@@ -740,9 +751,11 @@ _result = {{"matches": matches, "total_matched": total_matched}}
     if offset > 0:
         result["offset"] = offset
 
-    # Add cursor for next page
+    # Cursor is preferred; next_offset preserves the existing offset contract.
     if has_more:
-        result["cursor"] = offset + len(matches)
+        next_page = offset + len(matches)
+        result["cursor"] = next_page
+        result["next_offset"] = next_page
 
     if len(matches) >= max_results:
         result["warning"] = (

--- a/houdini_mcp/tools/nodes.py
+++ b/houdini_mcp/tools/nodes.py
@@ -373,6 +373,7 @@ def list_node_types(
         "total": total_matched,
         "returned": len(node_types),
         "has_more": has_more,
+        "offset": offset,
     }
 
     # Include category in result if filtered
@@ -539,6 +540,7 @@ def list_children(
         "total": paginated["total"],
         "returned": paginated["returned"],
         "has_more": paginated["has_more"],
+        "offset": max(0, int(cursor)) if cursor is not None else 0,
     }
 
     if paginated["has_more"]:
@@ -656,16 +658,14 @@ if root is not None:
             if total_matched <= offset:
                 continue
 
-            matches.append({{
-                "path": child.path(),
-                "name": child_name,
-                "type": child_type,
-            }})
-
-            # Keep counting exact totals after the page/lookahead is full, but
-            # stop materializing additional match records.
-            if len(matches) >= fetch_limit:
-                continue
+            # Keep counting exact totals, but materialize only one lookahead
+            # page to avoid path/type RPC work for every remaining match.
+            if len(matches) < fetch_limit:
+                matches.append({{
+                    "path": child.path(),
+                    "name": child_name,
+                    "type": child_type,
+                }})
 
 _result = {{"matches": matches, "total_matched": total_matched}}
 """.format(

--- a/houdini_mcp/tools/nodes.py
+++ b/houdini_mcp/tools/nodes.py
@@ -291,9 +291,11 @@ def delete_node(node_path: str, host: str = "localhost", port: int = 18811) -> d
 @handle_connection_errors("list_node_types")
 def list_node_types(
     category: str | None = None,
-    max_results: int = 100,
+    max_results: int | None = None,
     name_filter: str | None = None,
-    offset: int = 0,
+    offset: int | None = None,
+    limit: int | None = None,
+    cursor: int | None = None,
     host: str = "localhost",
     port: int = 18811,
 ) -> dict[str, Any]:
@@ -306,8 +308,14 @@ def list_node_types(
     Args:
         category: Optional category filter (e.g., "Object", "Sop", "Cop2", "Vop")
         max_results: Maximum number of results to return (default: 100, max: 500)
+                    DEPRECATED: Use limit instead for consistency
         name_filter: Optional substring filter for node type names (case-insensitive)
         offset: Number of results to skip for pagination (default: 0)
+               DEPRECATED: Use cursor instead for consistency
+        limit: Maximum number of results per page (default: 100, max: 500)
+              Preferred alias for max_results
+        cursor: Pagination cursor/offset (default: 0)
+               Preferred alias for offset
 
     Returns:
         Dict with list of node types and pagination info.
@@ -322,6 +330,17 @@ def list_node_types(
         - Subsequent calls: <1ms (filters from cache)
     """
     hou = ensure_connected(host, port)
+
+    # Backward-compatible aliases: limit/cursor take precedence over max_results/offset
+    if limit is not None:
+        max_results = limit
+    elif max_results is None:
+        max_results = 100
+
+    if cursor is not None:
+        offset = cursor
+    elif offset is None:
+        offset = 0
 
     # Cap max_results to prevent excessive data transfer
     if max_results > 500:
@@ -533,8 +552,10 @@ def find_nodes(
     root_path: str = "/obj",
     pattern: str = "*",
     node_type: str | None = None,
-    max_results: int = 100,
-    offset: int = 0,
+    max_results: int | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+    cursor: int | None = None,
     host: str = "localhost",
     port: int = 18811,
 ) -> dict[str, Any]:
@@ -545,8 +566,14 @@ def find_nodes(
         root_path: Root path to start search from
         pattern: Glob pattern or substring to match against node names (* for wildcard)
         node_type: Optional node type filter (e.g., "sphere", "noise", "geo")
-        max_results: Maximum number of results to return
+        max_results: Maximum number of results to return (default: 100)
+                    DEPRECATED: Use limit instead for consistency
         offset: Number of results to skip for pagination (default: 0)
+               DEPRECATED: Use cursor instead for consistency
+        limit: Maximum number of results per page (default: 100)
+              Preferred alias for max_results
+        cursor: Pagination cursor/offset (default: 0)
+               Preferred alias for offset
 
     Returns:
         Dict with matching nodes and their types.
@@ -562,6 +589,17 @@ def find_nodes(
     root = hou.node(root_path)
     if root is None:
         return {"status": "error", "message": f"Root node not found: {root_path}"}
+
+    # Backward-compatible aliases: limit/cursor take precedence over max_results/offset
+    if limit is not None:
+        max_results = limit
+    elif max_results is None:
+        max_results = 100
+
+    if cursor is not None:
+        offset = cursor
+    elif offset is None:
+        offset = 0
 
     # Validate offset
     if offset < 0:

--- a/tests/test_response_bounds.py
+++ b/tests/test_response_bounds.py
@@ -201,49 +201,9 @@ class TestResponseTruncation:
         assert reparsed["_truncated"] is True
 
 
-class TestCompactDetailModes:
-    """Test compact vs detail response modes."""
-
-    def test_compact_mode_reduces_fields(self):
-        """Compact mode excludes heavy fields."""
-        from houdini_mcp.tools._common import apply_detail_mode
-
-        full_data = {
-            "path": "/obj/geo1",
-            "type": "geo",
-            "parameters": {"tx": 1.0, "ty": 2.0, "tz": 3.0},
-            "children": [{"path": "/obj/geo1/sphere1"}],
-            "metadata": "heavy field" * 100,
-        }
-
-        compact = apply_detail_mode(full_data, mode="compact")
-        assert compact["path"] == "/obj/geo1"
-        assert compact["type"] == "geo"
-        assert "parameters" not in compact or compact.get("child_count") is not None
-        assert "metadata" not in compact
-
-    def test_detail_mode_includes_all_fields(self):
-        """Detail mode includes all fields."""
-        from houdini_mcp.tools._common import apply_detail_mode
-
-        full_data = {
-            "path": "/obj/geo1",
-            "type": "geo",
-            "parameters": {"tx": 1.0},
-            "children": [],
-        }
-
-        detail = apply_detail_mode(full_data, mode="detail")
-        assert detail == full_data
-
-    def test_standard_mode_is_default(self):
-        """Standard mode is a balanced default."""
-        from houdini_mcp.tools._common import apply_detail_mode
-
-        full_data = {"path": "/obj/geo1", "type": "geo", "parameters": {"tx": 1.0}}
-
-        standard = apply_detail_mode(full_data, mode="standard")
-        assert standard == full_data
+# NOTE: TestCompactDetailModes removed - apply_detail_mode was not wired to production
+# tools and has been removed from the PR scope. Compact mode is available via tool-specific
+# compact=True parameters (e.g., get_node_info, list_children) which is tested elsewhere.
 
 
 class TestPropertyBasedBounds:
@@ -361,3 +321,286 @@ class TestBackwardCompatibility:
         """Hard cap is opt-in during initial rollout."""
         # During migration, cap should be optional
         pass
+
+
+class TestProductionPathResponseCap:
+    """Test that production tools enforce hard caps on final serialized responses."""
+
+    def test_list_children_respects_cap(self, mock_connection):
+        """list_children final JSON response never exceeds cap."""
+        import json
+
+        from houdini_mcp.tools.nodes import list_children
+        from tests.conftest import MockHouNode
+
+        mock_hou = mock_connection
+
+        # Create a large child hierarchy
+        large_children = []
+        for i in range(200):
+            child = MockHouNode(
+                path=f"/obj/geo1/child{i}",
+                name=f"child{i}",
+                node_type="geo"
+            )
+            large_children.append(child)
+
+        # Create parent with many children
+        parent = MockHouNode(path="/obj/geo1", name="geo1", node_type="geo", children=large_children)
+        mock_hou.add_node(parent)
+
+        # Call with small cap
+        result = list_children("/obj/geo1", limit=100, host="localhost", port=18811)
+
+        # Serialize and measure final size
+        result_json = json.dumps(result, ensure_ascii=False)
+        result_bytes = len(result_json.encode("utf-8"))
+
+        # Should respect the DEFAULT_RESPONSE_CAP_BYTES (16KB)
+        from houdini_mcp.tools._common import DEFAULT_RESPONSE_CAP_BYTES
+        assert result_bytes <= DEFAULT_RESPONSE_CAP_BYTES, (
+            f"list_children response {result_bytes} bytes exceeds cap {DEFAULT_RESPONSE_CAP_BYTES}"
+        )
+
+    def test_find_nodes_respects_cap(self, mock_connection):
+        """find_nodes final JSON response never exceeds cap."""
+        import json
+
+        from houdini_mcp.tools.nodes import find_nodes
+        from tests.conftest import MockHouNode
+
+        mock_hou = mock_connection
+
+        # Create many nested nodes
+        children = []
+        for i in range(500):
+            child = MockHouNode(
+                path=f"/obj/sphere{i}",
+                name=f"sphere{i}",
+                node_type="sphere"
+            )
+            children.append(child)
+
+        # Create obj node with many children
+        obj = MockHouNode(path="/obj", name="obj", node_type="Object", children=children)
+        mock_hou.add_node(obj)
+
+        result = find_nodes("/obj", pattern="*", limit=200, host="localhost", port=18811)
+
+        # Serialize and measure
+        result_json = json.dumps(result, ensure_ascii=False)
+        result_bytes = len(result_json.encode("utf-8"))
+
+        from houdini_mcp.tools._common import DEFAULT_RESPONSE_CAP_BYTES
+        assert result_bytes <= DEFAULT_RESPONSE_CAP_BYTES
+
+    def test_list_node_types_respects_cap(self, mock_connection):
+        """list_node_types final JSON response never exceeds cap."""
+        import json
+
+        from houdini_mcp.tools.nodes import list_node_types
+
+        # Call with defaults (will populate cache and return results)
+        result = list_node_types(host="localhost", port=18811)
+
+        # Serialize and measure
+        result_json = json.dumps(result, ensure_ascii=False)
+        result_bytes = len(result_json.encode("utf-8"))
+
+        from houdini_mcp.tools._common import DEFAULT_RESPONSE_CAP_BYTES
+        assert result_bytes <= DEFAULT_RESPONSE_CAP_BYTES
+
+    def test_get_parameter_schema_respects_cap(self, mock_connection):
+        """get_parameter_schema final JSON response never exceeds cap."""
+        import json
+
+        from houdini_mcp.tools.parameters import get_parameter_schema
+        from tests.conftest import MockHouNode
+
+        mock_hou = mock_connection
+
+        # Create a node with many parameters
+        params = {}
+        for i in range(300):
+            params[f"parm{i}"] = 1.0
+
+        node = MockHouNode(
+            path="/obj/geo1",
+            name="geo1",
+            node_type="geo",
+            params=params
+        )
+        mock_hou.add_node(node)
+
+        result = get_parameter_schema("/obj/geo1", max_parms=200, host="localhost", port=18811)
+
+        # Serialize and measure
+        result_json = json.dumps(result, ensure_ascii=False)
+        result_bytes = len(result_json.encode("utf-8"))
+
+        from houdini_mcp.tools._common import DEFAULT_RESPONSE_CAP_BYTES
+        assert result_bytes <= DEFAULT_RESPONSE_CAP_BYTES
+
+    def test_get_geo_summary_respects_cap(self, mock_connection):
+        """get_geo_summary final JSON response never exceeds cap (via execute_code)."""
+        # get_geo_summary uses execute_code which handles its own response size
+        # The cap is applied at the _add_response_metadata level
+        # This is tested indirectly through execute_code output limits
+        pass
+
+
+class TestMultibyteResponseBoundaries:
+    """Test multibyte-safe truncation at response boundaries."""
+
+    def test_multibyte_string_in_capped_response(self):
+        """Multibyte UTF-8 strings don't break at response cap boundary."""
+        import json
+
+        from houdini_mcp.tools._common import apply_response_cap
+
+        # Create response with multibyte characters
+        data = {
+            "status": "success",
+            "items": [{"name": f"Node世界🌍{i}", "data": "测试数据" * 100} for i in range(100)],
+        }
+
+        result = apply_response_cap(data, max_bytes=2000)
+
+        # Must serialize without errors
+        result_json = json.dumps(result, ensure_ascii=False)
+        result_bytes = result_json.encode("utf-8")
+
+        # Must be under cap
+        assert len(result_bytes) <= 2000
+
+        # Must parse back (no broken multibyte sequences)
+        reparsed = json.loads(result_json)
+        assert reparsed["_truncated"] is True
+
+    def test_mixed_ascii_multibyte_truncation(self):
+        """Mixed ASCII and multibyte content truncates correctly."""
+        import json
+
+        from houdini_mcp.tools._common import apply_response_cap
+
+        data = {
+            "status": "success",
+            "english": "Hello World" * 50,
+            "chinese": "你好世界" * 50,
+            "japanese": "こんにちは世界" * 50,
+            "emoji": "🌍🌎🌏" * 50,
+            "mixed": "Hello世界🌍" * 50,
+        }
+
+        for cap in [500, 1000, 2000]:
+            result = apply_response_cap(data, max_bytes=cap)
+            result_json = json.dumps(result, ensure_ascii=False)
+            result_bytes = result_json.encode("utf-8")
+
+            # Must be under cap
+            assert len(result_bytes) <= cap
+
+            # Must be valid UTF-8
+            result_bytes.decode("utf-8")  # Would raise if broken
+
+            # Must parse
+            reparsed = json.loads(result_json)
+            assert "_truncated" in reparsed or len(result_bytes) < cap
+
+    def test_emoji_at_boundary(self):
+        """Emoji (4-byte UTF-8) at truncation boundary doesn't break."""
+        import json
+
+        from houdini_mcp.tools._common import apply_response_cap
+
+        # Emoji use 4 bytes in UTF-8
+        data = {
+            "status": "success",
+            "text": "🌍" * 1000,  # 4000 bytes
+        }
+
+        result = apply_response_cap(data, max_bytes=500)
+        result_json = json.dumps(result, ensure_ascii=False)
+
+        # Must be valid UTF-8
+        result_bytes = result_json.encode("utf-8")
+        result_bytes.decode("utf-8")  # Would raise if broken
+
+        # Must parse
+        reparsed = json.loads(result_json)
+        assert reparsed["_truncated"] is True
+
+
+class TestOversizedResponseRetainsUsefulData:
+    """Test that oversized responses retain useful bounded prefix, not just metadata."""
+
+    def test_large_list_preserves_items(self):
+        """Oversized list response preserves as many items as possible."""
+
+        from houdini_mcp.tools._common import apply_response_cap
+
+        data = {
+            "status": "success",
+            "items": [{"id": i, "name": f"item_{i}", "data": "x" * 50} for i in range(1000)],
+            "total": 1000,
+        }
+
+        result = apply_response_cap(data, max_bytes=5000)
+
+        # Should have truncated
+        assert result["_truncated"] is True
+
+        # Should preserve some items (not metadata-only)
+        assert "items" in result
+        assert len(result["items"]) > 0, "Should preserve useful data, not just metadata"
+
+        # Should have metadata about truncation
+        assert "items_truncated" in result
+        assert "items_original_count" in result
+        assert result["items_original_count"] == 1000
+
+        # Should preserve status and counts
+        assert result["status"] == "success"
+        assert result["total"] == 1000
+
+    def test_truncation_preserves_essential_fields(self):
+        """Truncation always preserves essential metadata fields."""
+        from houdini_mcp.tools._common import apply_response_cap
+
+        data = {
+            "status": "success",
+            "node_path": "/obj/geo1",
+            "total": 5000,
+            "returned": 100,
+            "has_more": True,
+            "cursor": 100,
+            "items": [{"large": "x" * 1000} for _ in range(100)],
+        }
+
+        result = apply_response_cap(data, max_bytes=2000)
+
+        # Essential fields should be preserved
+        assert result["status"] == "success"
+        assert result["node_path"] == "/obj/geo1"
+        assert result["total"] == 5000
+        assert result["returned"] == 100
+        assert result["has_more"] is True
+        assert result["cursor"] == 100
+
+    def test_minimal_response_not_metadata_only(self):
+        """Even minimal fallback response includes useful info."""
+        from houdini_mcp.tools._common import apply_response_cap
+
+        # Create extremely large response that won't fit even truncated
+        data = {
+            "status": "success",
+            "node_path": "/obj/geo1",
+            "items": [{"nested": {"deep": {"data": "x" * 10000}}} for _ in range(100)],
+        }
+
+        result = apply_response_cap(data, max_bytes=300)
+
+        # Should have minimal info
+        assert result["_truncated"] is True
+        assert result["status"] == "success"
+        assert "message" in result or "node_path" in result

--- a/tests/test_response_bounds.py
+++ b/tests/test_response_bounds.py
@@ -1,0 +1,363 @@
+"""Tests for response pagination, truncation, and size limits (HDMCP-52 / houdini-mcp-2t6).
+
+Strict TDD test suite for bounded MCP responses with pagination cursors,
+detail/compact modes, and hard size caps with multibyte-safe JSON truncation.
+"""
+
+import json
+
+
+class TestResponsePagination:
+    """Test pagination with limit/cursor/offset controls."""
+
+    def test_paginate_empty_list(self):
+        """Paginating an empty list returns empty result with no cursor."""
+        from houdini_mcp.tools._common import paginate_list
+
+        result = paginate_list([], limit=10)
+        assert result["items"] == []
+        assert result["total"] == 0
+        assert result["returned"] == 0
+        assert result["has_more"] is False
+        assert "cursor" not in result
+
+    def test_paginate_single_item(self):
+        """Paginating a single item returns it with no cursor."""
+        from houdini_mcp.tools._common import paginate_list
+
+        result = paginate_list([{"id": 1}], limit=10)
+        assert result["items"] == [{"id": 1}]
+        assert result["total"] == 1
+        assert result["returned"] == 1
+        assert result["has_more"] is False
+        assert "cursor" not in result
+
+    def test_paginate_under_limit(self):
+        """Items under limit return all items with no cursor."""
+        from houdini_mcp.tools._common import paginate_list
+
+        items = [{"id": i} for i in range(5)]
+        result = paginate_list(items, limit=10)
+        assert result["items"] == items
+        assert result["total"] == 5
+        assert result["returned"] == 5
+        assert result["has_more"] is False
+
+    def test_paginate_at_limit(self):
+        """Exactly at limit returns all items with no cursor."""
+        from houdini_mcp.tools._common import paginate_list
+
+        items = [{"id": i} for i in range(10)]
+        result = paginate_list(items, limit=10)
+        assert result["items"] == items
+        assert result["total"] == 10
+        assert result["returned"] == 10
+        assert result["has_more"] is False
+
+    def test_paginate_over_limit(self):
+        """Items over limit return limited items with cursor."""
+        from houdini_mcp.tools._common import paginate_list
+
+        items = [{"id": i} for i in range(25)]
+        result = paginate_list(items, limit=10)
+        assert len(result["items"]) == 10
+        assert result["items"] == items[:10]
+        assert result["total"] == 25
+        assert result["returned"] == 10
+        assert result["has_more"] is True
+        assert result["cursor"] == 10
+
+    def test_paginate_with_cursor(self):
+        """Using cursor returns next page."""
+        from houdini_mcp.tools._common import paginate_list
+
+        items = [{"id": i} for i in range(25)]
+        result = paginate_list(items, limit=10, cursor=10)
+        assert len(result["items"]) == 10
+        assert result["items"] == items[10:20]
+        assert result["total"] == 25
+        assert result["returned"] == 10
+        assert result["has_more"] is True
+        assert result["cursor"] == 20
+
+    def test_paginate_last_page(self):
+        """Last page returns remaining items with no cursor."""
+        from houdini_mcp.tools._common import paginate_list
+
+        items = [{"id": i} for i in range(25)]
+        result = paginate_list(items, limit=10, cursor=20)
+        assert len(result["items"]) == 5
+        assert result["items"] == items[20:25]
+        assert result["total"] == 25
+        assert result["returned"] == 5
+        assert result["has_more"] is False
+        assert "cursor" not in result
+
+    def test_paginate_cursor_beyond_end(self):
+        """Cursor beyond end returns empty page."""
+        from houdini_mcp.tools._common import paginate_list
+
+        items = [{"id": i} for i in range(25)]
+        result = paginate_list(items, limit=10, cursor=30)
+        assert result["items"] == []
+        assert result["total"] == 25
+        assert result["returned"] == 0
+        assert result["has_more"] is False
+
+
+class TestResponseTruncation:
+    """Test JSON-safe response truncation with metadata."""
+
+    def test_truncate_under_cap(self):
+        """Response under cap is not truncated."""
+        from houdini_mcp.tools._common import apply_response_cap
+
+        data = {"status": "success", "items": [1, 2, 3]}
+        result = apply_response_cap(data, max_bytes=1000)
+        assert result["status"] == "success"
+        assert result["items"] == [1, 2, 3]
+        assert "_truncated" not in result
+
+    def test_truncate_at_cap(self):
+        """Response at cap boundary is not truncated."""
+        from houdini_mcp.tools._common import apply_response_cap
+
+        data = {"status": "success", "value": "x" * 100}
+        json_str = json.dumps(data)
+        cap = len(json_str)
+        result = apply_response_cap(data, max_bytes=cap)
+        assert "_truncated" not in result
+
+    def test_truncate_over_cap(self):
+        """Response over cap is truncated with metadata."""
+        from houdini_mcp.tools._common import apply_response_cap
+
+        data = {"status": "success", "items": list(range(1000))}
+        result = apply_response_cap(data, max_bytes=500)
+
+        # Should have truncation metadata
+        assert result["_truncated"] is True
+        assert "original_size_bytes" in result
+        assert result["original_size_bytes"] > 500
+        assert "truncated_size_bytes" in result
+        assert result["truncated_size_bytes"] <= 500
+
+        # Result must be valid JSON
+        result_json = json.dumps(result)
+        assert len(result_json) <= 500
+
+        # Must parse back
+        reparsed = json.loads(result_json)
+        assert reparsed["_truncated"] is True
+
+    def test_truncate_nested_fields(self):
+        """Truncation works with deeply nested fields."""
+        from houdini_mcp.tools._common import apply_response_cap
+
+        data = {
+            "status": "success",
+            "nested": {"deep": {"items": list(range(1000))}},
+        }
+        result = apply_response_cap(data, max_bytes=300)
+        assert result["_truncated"] is True
+        json_str = json.dumps(result)
+        assert len(json_str) <= 300
+
+    def test_truncate_multibyte_strings(self):
+        """Truncation is multibyte-safe (UTF-8)."""
+        from houdini_mcp.tools._common import apply_response_cap
+
+        # Unicode characters (emoji, CJK) use multiple bytes
+        data = {"status": "success", "text": "Hello 世界 🌍" * 100}
+        result = apply_response_cap(data, max_bytes=200)
+
+        # Result must be valid JSON (no broken multibyte sequences)
+        result_json = json.dumps(result, ensure_ascii=False)
+        assert len(result_json.encode("utf-8")) <= 200
+
+        # Must parse back without Unicode errors
+        reparsed = json.loads(result_json)
+        assert reparsed["_truncated"] is True
+
+    def test_truncate_preserves_status(self):
+        """Truncation always preserves status field."""
+        from houdini_mcp.tools._common import apply_response_cap
+
+        data = {"status": "error", "message": "x" * 1000, "items": list(range(1000))}
+        result = apply_response_cap(data, max_bytes=200)
+        assert result["status"] == "error"
+        assert "_truncated" in result
+
+    def test_truncate_malformed_json_recovery(self):
+        """If truncation would create invalid JSON, it's fixed."""
+        from houdini_mcp.tools._common import apply_response_cap
+
+        data = {"items": ["a" * 500, "b" * 500, "c" * 500]}
+        result = apply_response_cap(data, max_bytes=300)
+
+        # Must be valid JSON
+        result_json = json.dumps(result)
+        reparsed = json.loads(result_json)
+        assert reparsed["_truncated"] is True
+
+
+class TestCompactDetailModes:
+    """Test compact vs detail response modes."""
+
+    def test_compact_mode_reduces_fields(self):
+        """Compact mode excludes heavy fields."""
+        from houdini_mcp.tools._common import apply_detail_mode
+
+        full_data = {
+            "path": "/obj/geo1",
+            "type": "geo",
+            "parameters": {"tx": 1.0, "ty": 2.0, "tz": 3.0},
+            "children": [{"path": "/obj/geo1/sphere1"}],
+            "metadata": "heavy field" * 100,
+        }
+
+        compact = apply_detail_mode(full_data, mode="compact")
+        assert compact["path"] == "/obj/geo1"
+        assert compact["type"] == "geo"
+        assert "parameters" not in compact or compact.get("child_count") is not None
+        assert "metadata" not in compact
+
+    def test_detail_mode_includes_all_fields(self):
+        """Detail mode includes all fields."""
+        from houdini_mcp.tools._common import apply_detail_mode
+
+        full_data = {
+            "path": "/obj/geo1",
+            "type": "geo",
+            "parameters": {"tx": 1.0},
+            "children": [],
+        }
+
+        detail = apply_detail_mode(full_data, mode="detail")
+        assert detail == full_data
+
+    def test_standard_mode_is_default(self):
+        """Standard mode is a balanced default."""
+        from houdini_mcp.tools._common import apply_detail_mode
+
+        full_data = {"path": "/obj/geo1", "type": "geo", "parameters": {"tx": 1.0}}
+
+        standard = apply_detail_mode(full_data, mode="standard")
+        assert standard == full_data
+
+
+class TestPropertyBasedBounds:
+    """Property tests that no response exceeds configured cap."""
+
+    def test_no_response_exceeds_cap_property(self):
+        """Property: apply_response_cap never returns JSON larger than cap."""
+        from houdini_mcp.tools._common import apply_response_cap
+
+        for size in [100, 500, 1000, 5000, 16000]:
+            # Generate various data structures
+            data_samples = [
+                {"items": list(range(10000))},
+                {"text": "a" * 50000},
+                {"nested": {"deep": {"value": list(range(1000))}}},
+                {"status": "success", "data": {"x": "y" * 10000}},
+            ]
+
+            for data in data_samples:
+                result = apply_response_cap(data, max_bytes=size)
+                result_json = json.dumps(result)
+                result_bytes = len(result_json.encode("utf-8"))
+
+                # Property: result is always within cap
+                assert result_bytes <= size, (
+                    f"Response {result_bytes} bytes exceeds cap {size} bytes"
+                )
+
+                # Property: result is always valid JSON
+                reparsed = json.loads(result_json)
+                assert isinstance(reparsed, dict)
+
+    def test_truncated_responses_always_valid_json(self):
+        """Property: truncated responses are always valid, parseable JSON."""
+        from houdini_mcp.tools._common import apply_response_cap
+
+        test_cases = [
+            {"items": list(range(10000))},
+            {"text": "🌍" * 5000},  # Multibyte
+            {"nested": {"a": {"b": {"c": list(range(1000))}}}},
+        ]
+
+        for data in test_cases:
+            for cap in [100, 200, 500, 1000, 16000]:
+                result = apply_response_cap(data, max_bytes=cap)
+                result_json = json.dumps(result, ensure_ascii=False)
+
+                # Must parse without errors
+                reparsed = json.loads(result_json)
+                assert isinstance(reparsed, dict)
+
+
+class TestPerformanceAndSize:
+    """Performance and size tests for response bounds."""
+
+    def test_large_list_pagination_performance(self):
+        """Pagination on large lists is fast."""
+        import time
+
+        from houdini_mcp.tools._common import paginate_list
+
+        large_list = [{"id": i, "data": "x" * 100} for i in range(10000)]
+
+        start = time.time()
+        result = paginate_list(large_list, limit=20)
+        elapsed = time.time() - start
+
+        assert elapsed < 0.1  # Should be near instant
+        assert len(result["items"]) == 20
+        assert result["total"] == 10000
+
+    def test_truncation_performance(self):
+        """Truncation on large responses is reasonably fast."""
+        import time
+
+        from houdini_mcp.tools._common import apply_response_cap
+
+        large_data = {"items": list(range(100000)), "text": "a" * 100000}
+
+        start = time.time()
+        result = apply_response_cap(large_data, max_bytes=16000)
+        elapsed = time.time() - start
+
+        assert elapsed < 1.0  # Should complete within 1 second
+        assert result["_truncated"] is True
+
+    def test_multibyte_string_truncation_correctness(self):
+        """Multibyte truncation doesn't break character boundaries."""
+        from houdini_mcp.tools._common import apply_response_cap
+
+        # Mix of ASCII and multibyte
+        data = {"text": "Hello世界🌍" * 1000}
+
+        result = apply_response_cap(data, max_bytes=500)
+        result_json = json.dumps(result, ensure_ascii=False)
+
+        # Must be valid UTF-8
+        result_json.encode("utf-8")  # Would raise if broken
+
+        # Must parse
+        reparsed = json.loads(result_json)
+        assert reparsed["_truncated"] is True
+
+
+class TestBackwardCompatibility:
+    """Tests for backward compatibility with existing tools."""
+
+    def test_pagination_optional_in_existing_tools(self):
+        """Pagination is opt-in; existing calls still work."""
+        # This will be tested when we update actual tools
+        # Placeholder for now
+        pass
+
+    def test_cap_disabled_by_default_initially(self):
+        """Hard cap is opt-in during initial rollout."""
+        # During migration, cap should be optional
+        pass

--- a/tests/test_response_bounds.py
+++ b/tests/test_response_bounds.py
@@ -10,6 +10,14 @@ import json
 class TestResponsePagination:
     """Test pagination with limit/cursor/offset controls."""
 
+    def test_invalid_inputs_are_clamped_without_repeating_cursor(self):
+        from houdini_mcp.tools._common import paginate_list
+
+        result = paginate_list(list(range(5)), limit=0, cursor=-100)
+        assert result["items"] == [0]
+        assert result["cursor"] == 1
+        assert result["has_more"] is True
+
     def test_paginate_empty_list(self):
         """Paginating an empty list returns empty result with no cursor."""
         from houdini_mcp.tools._common import paginate_list
@@ -103,6 +111,24 @@ class TestResponsePagination:
         assert result["total"] == 25
         assert result["returned"] == 0
         assert result["has_more"] is False
+
+
+class TestLegacyPaginationCompatibility:
+    def test_direct_positional_host_port_calls_still_work(self, mock_connection):
+        from houdini_mcp.tools.nodes import find_nodes, list_children, list_node_types
+
+        assert list_node_types(None, 10, None, 0, "localhost", 18811)["status"] == "success"
+        assert (
+            list_children("/obj", False, 10, 1000, True, "localhost", 18811)["status"] == "success"
+        )
+        assert find_nodes("/obj", "*", None, 10, 0, "localhost", 18811)["status"] == "success"
+
+    def test_next_offset_alias_is_preserved(self, mock_connection):
+        from houdini_mcp.tools.nodes import list_node_types
+
+        result = list_node_types(limit=1, cursor=0, host="localhost", port=18811)
+        assert result["has_more"] is True
+        assert result["next_offset"] == result["cursor"] == 1
 
 
 class TestResponseTruncation:

--- a/tests/test_response_bounds.py
+++ b/tests/test_response_bounds.py
@@ -564,6 +564,62 @@ class TestProductionPathResponseCap:
         assert preserved_something, "Truncated response should retain useful bounded data"
 
 
+class TestSemanticTruncation:
+    def test_truncated_page_cursor_advances_by_preserved_count(self):
+        from houdini_mcp.tools._common import apply_response_cap
+
+        result = apply_response_cap(
+            {
+                "status": "success",
+                "children": [{"name": f"n{i}", "detail": "x" * 300} for i in range(20)],
+                "returned": 20,
+                "count": 20,
+                "total": 20,
+                "has_more": False,
+            },
+            max_bytes=1400,
+        )
+        preserved = len(result["children"])
+        assert 0 < preserved < 20
+        assert result["returned"] == result["count"] == preserved
+        assert result["has_more"] is True
+        assert result["cursor"] == result["next_offset"] == preserved
+
+    def test_nested_geometry_categories_keep_bounded_prefixes(self):
+        from houdini_mcp.tools._common import apply_response_cap
+
+        result = apply_response_cap(
+            {
+                "status": "success",
+                "attributes": {
+                    "point": [{"name": f"p{i}", "detail": "x" * 100} for i in range(100)],
+                    "primitive": [{"name": f"pr{i}", "detail": "x" * 100} for i in range(100)],
+                },
+            },
+            max_bytes=1800,
+        )
+        assert result["attributes"]
+        assert result["attributes_category_counts"]["point"]["original"] == 100
+        assert _json_size(result) <= 1800
+
+    def test_diagnostic_lists_are_preserved(self):
+        from houdini_mcp.tools._common import apply_response_cap
+
+        result = apply_response_cap(
+            {
+                "status": "success",
+                "error_nodes": [{"path": f"/obj/n{i}", "error": "x" * 200} for i in range(100)],
+            },
+            max_bytes=1500,
+        )
+        assert result["error_nodes"]
+        assert result["error_nodes_truncated"] is True
+
+
+def _json_size(value):
+    return len(json.dumps(value, ensure_ascii=False).encode("utf-8"))
+
+
 class TestFinalSerializedSizeAccounting:
     """The cap applies to the final object, including metadata added by finalization."""
 
@@ -733,9 +789,10 @@ class TestOversizedResponseRetainsUsefulData:
         assert result["status"] == "success"
         assert result["node_path"] == "/obj/geo1"
         assert result["total"] == 5000
-        assert result["returned"] == 100
+        preserved = len(result["items"])
+        assert result["returned"] == result["count"] == preserved
         assert result["has_more"] is True
-        assert result["cursor"] == 100
+        assert result["cursor"] == result["next_offset"] == preserved
 
     def test_minimal_response_not_metadata_only(self):
         """Even minimal fallback response includes useful info."""

--- a/tests/test_response_bounds.py
+++ b/tests/test_response_bounds.py
@@ -338,15 +338,13 @@ class TestProductionPathResponseCap:
         # Create a large child hierarchy
         large_children = []
         for i in range(200):
-            child = MockHouNode(
-                path=f"/obj/geo1/child{i}",
-                name=f"child{i}",
-                node_type="geo"
-            )
+            child = MockHouNode(path=f"/obj/geo1/child{i}", name=f"child{i}", node_type="geo")
             large_children.append(child)
 
         # Create parent with many children
-        parent = MockHouNode(path="/obj/geo1", name="geo1", node_type="geo", children=large_children)
+        parent = MockHouNode(
+            path="/obj/geo1", name="geo1", node_type="geo", children=large_children
+        )
         mock_hou.add_node(parent)
 
         # Call with small cap
@@ -358,6 +356,7 @@ class TestProductionPathResponseCap:
 
         # Should respect the DEFAULT_RESPONSE_CAP_BYTES (16KB)
         from houdini_mcp.tools._common import DEFAULT_RESPONSE_CAP_BYTES
+
         assert result_bytes <= DEFAULT_RESPONSE_CAP_BYTES, (
             f"list_children response {result_bytes} bytes exceeds cap {DEFAULT_RESPONSE_CAP_BYTES}"
         )
@@ -374,11 +373,7 @@ class TestProductionPathResponseCap:
         # Create many nested nodes
         children = []
         for i in range(500):
-            child = MockHouNode(
-                path=f"/obj/sphere{i}",
-                name=f"sphere{i}",
-                node_type="sphere"
-            )
+            child = MockHouNode(path=f"/obj/sphere{i}", name=f"sphere{i}", node_type="sphere")
             children.append(child)
 
         # Create obj node with many children
@@ -392,6 +387,7 @@ class TestProductionPathResponseCap:
         result_bytes = len(result_json.encode("utf-8"))
 
         from houdini_mcp.tools._common import DEFAULT_RESPONSE_CAP_BYTES
+
         assert result_bytes <= DEFAULT_RESPONSE_CAP_BYTES
 
     def test_list_node_types_respects_cap(self, mock_connection):
@@ -408,6 +404,7 @@ class TestProductionPathResponseCap:
         result_bytes = len(result_json.encode("utf-8"))
 
         from houdini_mcp.tools._common import DEFAULT_RESPONSE_CAP_BYTES
+
         assert result_bytes <= DEFAULT_RESPONSE_CAP_BYTES
 
     def test_get_parameter_schema_respects_cap(self, mock_connection):
@@ -424,12 +421,7 @@ class TestProductionPathResponseCap:
         for i in range(300):
             params[f"parm{i}"] = 1.0
 
-        node = MockHouNode(
-            path="/obj/geo1",
-            name="geo1",
-            node_type="geo",
-            params=params
-        )
+        node = MockHouNode(path="/obj/geo1", name="geo1", node_type="geo", params=params)
         mock_hou.add_node(node)
 
         result = get_parameter_schema("/obj/geo1", max_parms=200, host="localhost", port=18811)
@@ -439,14 +431,146 @@ class TestProductionPathResponseCap:
         result_bytes = len(result_json.encode("utf-8"))
 
         from houdini_mcp.tools._common import DEFAULT_RESPONSE_CAP_BYTES
+
         assert result_bytes <= DEFAULT_RESPONSE_CAP_BYTES
 
-    def test_get_geo_summary_respects_cap(self, mock_connection):
-        """get_geo_summary final JSON response never exceeds cap (via execute_code)."""
-        # get_geo_summary uses execute_code which handles its own response size
-        # The cap is applied at the _add_response_metadata level
-        # This is tested indirectly through execute_code output limits
-        pass
+    def test_get_geo_summary_respects_cap(self):
+        """get_geo_summary final JSON response never exceeds cap.
+
+        Exercises the real production path: get_geo_summary() -> execute_code()
+        -> _add_response_metadata() -> apply_response_cap(). Only execute_code's
+        Houdini-side execution is mocked (it returns oversized geometry JSON on
+        stdout, as the real Houdini-side analysis code would for a dense mesh);
+        the response-bounding logic itself is exercised for real.
+        """
+        from unittest.mock import patch
+
+        from houdini_mcp.tools import get_geo_summary
+        from houdini_mcp.tools._common import DEFAULT_RESPONSE_CAP_BYTES
+
+        # Build an oversized geometry summary: many attributes, many groups,
+        # and many sample points with several attribute values each. This
+        # mirrors what a dense production SOP (many named attributes/groups)
+        # would produce before bounding is applied.
+        point_attrs = [{"name": f"point_attr_{i}", "type": "float", "size": 3} for i in range(200)]
+        prim_attrs = [{"name": f"prim_attr_{i}", "type": "string", "size": 1} for i in range(200)]
+        vertex_attrs = [{"name": f"vertex_attr_{i}", "type": "float", "size": 2} for i in range(50)]
+        detail_attrs = [{"name": f"detail_attr_{i}", "type": "int", "size": 1} for i in range(50)]
+
+        point_groups = [f"point_group_{i}" for i in range(200)]
+        prim_groups = [f"prim_group_{i}" for i in range(200)]
+
+        sample_points = [
+            {
+                "index": i,
+                "P": [float(i), float(i) * 2, float(i) * 3],
+                "N": [0.0, 1.0, 0.0],
+                "Cd": [1.0, 0.5, 0.25],
+                "extra_attr": f"sample_point_payload_{i}" * 5,
+            }
+            for i in range(16)
+        ]
+
+        oversized_geo_data = {
+            "status": "success",
+            "node_path": "/obj/geo1/dense_mesh1",
+            "cook_state": "cooked",
+            "point_count": 500000,
+            "primitive_count": 250000,
+            "vertex_count": 1000000,
+            "bounding_box": {
+                "min": [-10.0, -10.0, -10.0],
+                "max": [10.0, 10.0, 10.0],
+                "size": [20.0, 20.0, 20.0],
+                "center": [0.0, 0.0, 0.0],
+            },
+            "attributes": {
+                "point": point_attrs,
+                "primitive": prim_attrs,
+                "vertex": vertex_attrs,
+                "detail": detail_attrs,
+            },
+            "groups": {
+                "point": point_groups,
+                "primitive": prim_groups,
+            },
+            "sample_points": sample_points,
+        }
+
+        oversized_json = json.dumps(oversized_geo_data)
+        # Sanity check the fixture is actually oversized relative to the cap;
+        # otherwise this test would not be exercising truncation at all.
+        assert len(oversized_json.encode("utf-8")) > DEFAULT_RESPONSE_CAP_BYTES
+
+        with patch("houdini_mcp.tools.code.execute_code") as mock_execute_code:
+            mock_execute_code.return_value = {
+                "status": "success",
+                "stdout": oversized_json,
+                "stderr": "",
+            }
+
+            result = get_geo_summary(
+                "/obj/geo1/dense_mesh1",
+                max_sample_points=16,
+                host="localhost",
+                port=18811,
+            )
+
+        # Final serialized response (as returned to the MCP client) must
+        # respect the hard cap.
+        result_json = json.dumps(result, ensure_ascii=False)
+        result_bytes = len(result_json.encode("utf-8"))
+        assert result_bytes <= DEFAULT_RESPONSE_CAP_BYTES, (
+            f"get_geo_summary response {result_bytes} bytes exceeds cap "
+            f"{DEFAULT_RESPONSE_CAP_BYTES}"
+        )
+
+        # It must actually have been truncated (proves the cap engaged, not
+        # just that the mock happened to be small).
+        assert result["_truncated"] is True
+        assert result["status"] == "success"
+        assert result["node_path"] == "/obj/geo1/dense_mesh1"
+
+        # Truncation retains useful bounded data, not metadata-only.
+        preserved_something = any(
+            key in result and result[key] for key in ("attributes", "groups", "sample_points")
+        )
+        assert preserved_something, "Truncated response should retain useful bounded data"
+
+
+class TestFinalSerializedSizeAccounting:
+    """The cap applies to the final object, including metadata added by finalization."""
+
+    def test_metadata_added_after_initial_measurement_cannot_cross_cap(self):
+        """A near-cap response is re-capped after size metadata is inserted."""
+        from houdini_mcp.tools._common import _add_response_metadata
+
+        cap = 200
+        # This payload is 172 bytes before metadata, but the size metadata pushes
+        # it to 201 bytes unless finalization performs a second cap pass.
+        payload = {"status": "success", "items": ["x" * 136]}
+        assert len(json.dumps(payload).encode("utf-8")) < cap
+
+        result = _add_response_metadata(payload, max_bytes=cap)
+
+        assert len(json.dumps(result, ensure_ascii=False).encode("utf-8")) <= cap
+
+    def test_truncated_size_bytes_equals_final_serialized_size(self):
+        """Self-referential byte-count metadata converges to the final JSON size."""
+        from houdini_mcp.tools._common import apply_response_cap
+
+        result = apply_response_cap(
+            {
+                "status": "success",
+                "items": [{"name": f"item-{i}", "data": "世界🌍" * 40} for i in range(100)],
+            },
+            max_bytes=1200,
+        )
+        final_size = len(json.dumps(result, ensure_ascii=False).encode("utf-8"))
+
+        assert result["_truncated"] is True
+        assert result["truncated_size_bytes"] == final_size
+        assert final_size <= 1200
 
 
 class TestMultibyteResponseBoundaries:

--- a/tests/test_response_bounds.py
+++ b/tests/test_response_bounds.py
@@ -649,6 +649,52 @@ def _json_size(value):
     return len(json.dumps(value, ensure_ascii=False).encode("utf-8"))
 
 
+class TestGenericPayloadPreservation:
+    def test_execute_code_text_keeps_bounded_prefix(self):
+        from houdini_mcp.tools._common import apply_response_cap
+
+        result = apply_response_cap(
+            {"status": "success", "stdout": "hello" * 10000, "stderr": "warn" * 10000},
+            max_bytes=1800,
+        )
+        assert result["stdout"].startswith("hello")
+        assert result["stdout_truncated"] is True
+        assert _json_size(result) <= 1800
+
+    def test_single_oversized_parameter_keeps_identity(self):
+        from houdini_mcp.tools._common import apply_response_cap
+
+        result = apply_response_cap(
+            {
+                "status": "success",
+                "parameters": [
+                    {"name": "mode", "type": "menu", "menu_items": ["x" * 100 for _ in range(1000)]}
+                ],
+                "count": 1,
+            },
+            max_bytes=1600,
+        )
+        assert result["parameters"]
+        assert "name" in result["parameters"][0]
+        assert result["count"] == 1
+
+    def test_bounding_box_survives_geometry_cap(self):
+        from houdini_mcp.tools._common import apply_response_cap
+
+        bbox = {"min": [0, 0, 0], "max": [1, 1, 1]}
+        result = apply_response_cap(
+            {
+                "status": "success",
+                "bounding_box": bbox,
+                "attributes": {
+                    "point": [{"name": str(i), "detail": "x" * 100} for i in range(1000)]
+                },
+            },
+            max_bytes=1800,
+        )
+        assert result["bounding_box"] == bbox
+
+
 class TestFinalSerializedSizeAccounting:
     """The cap applies to the final object, including metadata added by finalization."""
 

--- a/tests/test_response_bounds.py
+++ b/tests/test_response_bounds.py
@@ -130,6 +130,17 @@ class TestLegacyPaginationCompatibility:
         assert result["has_more"] is True
         assert result["next_offset"] == result["cursor"] == 1
 
+    def test_find_nodes_clamps_zero_limit(self, mock_connection):
+        from houdini_mcp.tools.nodes import find_nodes
+        from tests.conftest import MockHouNode
+
+        obj = mock_connection.node("/obj")
+        child = MockHouNode(path="/obj/geo1", name="geo1", node_type="geo")
+        obj._children.append(child)
+        result = find_nodes(limit=0, cursor=0, host="localhost", port=18811)
+        assert result["returned"] == 1
+        assert result["matches"][0]["path"] == "/obj/geo1"
+
 
 class TestResponseTruncation:
     """Test JSON-safe response truncation with metadata."""
@@ -614,6 +625,24 @@ class TestSemanticTruncation:
         )
         assert result["error_nodes"]
         assert result["error_nodes_truncated"] is True
+
+    def test_capped_page_preserves_next_offset(self):
+        from houdini_mcp.tools._common import apply_response_cap
+
+        result = apply_response_cap(
+            {
+                "status": "success",
+                "children": [{"name": f"n{i}", "detail": "x" * 300} for i in range(20)],
+                "returned": 20,
+                "count": 20,
+                "total": 100,
+                "has_more": True,
+                "cursor": 20,
+                "next_offset": 20,
+            },
+            max_bytes=1400,
+        )
+        assert result["next_offset"] == result["cursor"] == len(result["children"])
 
 
 def _json_size(value):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2819,20 +2819,22 @@ class TestResponseSizeMetadata:
         assert "_response_size_warning" not in augmented
 
     def test_add_response_metadata_large_response(self):
-        """Test that large responses get warning metadata."""
+        """Test that large responses get capped with truncation metadata."""
         from houdini_mcp.tools import RESPONSE_SIZE_LARGE_THRESHOLD, _add_response_metadata
 
-        # Create a response larger than the threshold
+        # Create a response larger than the threshold (will be capped at DEFAULT_RESPONSE_CAP_BYTES)
         large_data = "x" * (RESPONSE_SIZE_LARGE_THRESHOLD + 1000)
         result = {"status": "success", "data": large_data}
         augmented = _add_response_metadata(result)
 
-        assert "_response_size_bytes" in augmented
-        assert "_response_size_warning" in augmented
-        assert "Large response" in augmented["_response_size_warning"]
+        # Large responses are now capped, so they have truncation metadata
+        assert "_truncated" in augmented
+        assert augmented["_truncated"] is True
+        assert "original_size_bytes" in augmented
+        assert "truncated_size_bytes" in augmented
 
     def test_add_response_metadata_medium_response(self):
-        """Test that medium responses get a note but not a warning."""
+        """Test that medium responses (between warning and large) get capped."""
         from houdini_mcp.tools import (
             RESPONSE_SIZE_LARGE_THRESHOLD,
             RESPONSE_SIZE_WARNING_THRESHOLD,
@@ -2840,14 +2842,16 @@ class TestResponseSizeMetadata:
         )
 
         # Create a response between warning and large thresholds
+        # This will still exceed DEFAULT_RESPONSE_CAP_BYTES (16KB) so it gets capped
         medium_size = (RESPONSE_SIZE_WARNING_THRESHOLD + RESPONSE_SIZE_LARGE_THRESHOLD) // 2
         medium_data = "x" * medium_size
         result = {"status": "success", "data": medium_data}
         augmented = _add_response_metadata(result)
 
-        assert "_response_size_bytes" in augmented
-        assert "_response_size_note" in augmented
-        assert "_response_size_warning" not in augmented
+        # Medium-large responses get capped at 16KB
+        assert "_truncated" in augmented
+        assert augmented["_truncated"] is True
+        assert "original_size_bytes" in augmented
 
     def test_estimate_response_size(self):
         """Test response size estimation."""


### PR DESCRIPTION
## Summary
Implements `houdini-mcp-2t6`: a shared production response-finalization boundary with an exact 16KB UTF-8 JSON cap, useful-prefix truncation metadata, bounded geometry samples (default 16), and backward-compatible `limit`/`cursor` aliases for node listing/search APIs.

This PR deliberately does **not** claim a universal detail-mode API. Per-tool compact/detail expansion remains canonical follow-up bead `houdini-mcp-16w`.

## Reliability properties
- Cap is enforced on the FINAL serialized object, including size/warning metadata.
- `truncated_size_bytes` equals the exact final JSON byte count (fixed point including itself).
- Oversized lists retain the longest useful prefix using O(log n) search plus continuation/truncation metadata.
- UTF-8 multibyte boundaries stay valid.
- `get_geo_summary` defaults to 16 samples and has a real oversized production-path cap test.
- `find_nodes` / `list_node_types` support preferred `limit`/`cursor` while preserving `max_results`/`offset`.

## Tests
- `tests/test_response_bounds.py`: 35 focused cap/pagination/multibyte/performance tests.
- Full suite after rebase on main: **577 passed, 12 skipped**.
- `ruff format --check .` and `ruff check .` green.

Refs `houdini-mcp-2t6`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination controls and continuation metadata to node type listings, child listings, and node searches.
  * Added automatic response-size limits that preserve essential information while indicating truncated content.
  * Improved response size reporting with accurate serialized byte counts.

* **Updates**
  * Reduced the default geometry sample size from 100 to 16 points.
  * Maintained compatibility with existing offset- and result-limit-based requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->