### PR TITLE
feat: complete compact list_children contract (houdini-mcp-16w)

### DIFF
--- a/houdini_mcp/tools/nodes.py
+++ b/houdini_mcp/tools/nodes.py
@@ -453,6 +453,15 @@ def list_children(
     children_list: list[dict[str, Any]] = []
     nodes_collected = 0
 
+    def compact_flag(node: Any, method: str) -> str:
+        getter = getattr(node, method, None)
+        if not callable(getter):
+            return "-"
+        try:
+            return "1" if bool(getter()) else "0"
+        except Exception:
+            return "-"
+
     def collect_children(node: Any, depth: int = 0) -> None:
         nonlocal nodes_collected
 
@@ -475,13 +484,12 @@ def list_children(
                         "path": child.path(),
                         "name": child.name(),
                         "type": child.type().name(),
-                        # Pack stable flags to avoid three repeated JSON keys per
-                        # node while keeping the compact contract explicit.
-                        "flags": {
-                            "display": bool(child.isDisplayFlagSet()),
-                            "render": bool(child.isRenderFlagSet()),
-                            "bypassed": bool(child.isBypassed()),
-                        },
+                        # Three-character bitset: display/render/bypassed. `-`
+                        # means the node class does not expose that flag API.
+                        "flags": "".join(
+                            compact_flag(child, method)
+                            for method in ("isDisplayFlagSet", "isRenderFlagSet", "isBypassed")
+                        ),
                     }
                 else:
                     # Full mode: include input/output connection details

--- a/houdini_mcp/tools/nodes.py
+++ b/houdini_mcp/tools/nodes.py
@@ -475,6 +475,13 @@ def list_children(
                         "path": child.path(),
                         "name": child.name(),
                         "type": child.type().name(),
+                        # Pack stable flags to avoid three repeated JSON keys per
+                        # node while keeping the compact contract explicit.
+                        "flags": {
+                            "display": bool(child.isDisplayFlagSet()),
+                            "render": bool(child.isRenderFlagSet()),
+                            "bypassed": bool(child.isBypassed()),
+                        },
                     }
                 else:
                     # Full mode: include input/output connection details

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1464,9 +1464,22 @@ class TestListChildren:
             assert "name" in child
             assert "type" in child
             assert set(child) == {"path", "name", "type", "flags"}
-            assert set(child["flags"]) == {"display", "render", "bypassed"}
+            assert len(child["flags"]) == 3
+            assert set(child["flags"]) <= {"0", "1", "-"}
             assert "inputs" not in child
             assert "outputs" not in child
+
+    def test_compact_flags_are_optional_per_node(self, mock_connection, monkeypatch):
+        from houdini_mcp.tools import list_children
+
+        child = MockHouNode(path="/obj/geo1/custom", name="custom", node_type="custom")
+        monkeypatch.setattr(child, "isRenderFlagSet", None)
+        mock_connection.add_node(
+            MockHouNode(path="/obj/geo1", name="geo1", node_type="geo", children=[child])
+        )
+        result = list_children("/obj/geo1", compact=True, host="localhost", port=18811)
+        assert result["returned"] == 1
+        assert result["children"][0]["flags"][1] == "-"
 
     def test_list_children_compact_preserves_pagination_and_cap(self, mock_connection):
         from houdini_mcp.tools import list_children

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1463,8 +1463,53 @@ class TestListChildren:
             assert "path" in child
             assert "name" in child
             assert "type" in child
+            assert set(child) == {"path", "name", "type", "flags"}
+            assert set(child["flags"]) == {"display", "render", "bypassed"}
             assert "inputs" not in child
             assert "outputs" not in child
+
+    def test_list_children_compact_preserves_pagination_and_cap(self, mock_connection):
+        from houdini_mcp.tools import list_children
+
+        children = [
+            MockHouNode(path=f"/obj/geo1/n{i}", name=f"n{i}", node_type="null") for i in range(50)
+        ]
+        mock_connection.add_node(
+            MockHouNode(path="/obj/geo1", name="geo1", node_type="geo", children=children)
+        )
+        result = list_children(
+            "/obj/geo1", compact=True, limit=10, cursor=10, host="localhost", port=18811
+        )
+        assert result["returned"] == 10
+        assert result["total"] == result["count"] == 50
+        assert result["cursor"] == result["next_offset"] == 20
+        assert result["offset"] == 10
+
+    def test_compact_payload_is_at_least_sixty_percent_smaller(self, mock_connection):
+        import json
+
+        from houdini_mcp.tools import list_children
+
+        children = []
+        # Stay below the shared 16KB response cap so this measures compact
+        # representation savings rather than comparing two equally capped JSON blobs.
+        for i in range(20):
+            node = MockHouNode(path=f"/obj/geo1/node_{i}", name=f"node_{i}", node_type="null")
+            node._inputs = [
+                MockHouNode(path=f"/obj/source_{i}_{j}", name=f"source_{i}_{j}") for j in range(4)
+            ]
+            node._outputs = [
+                MockHouNode(path=f"/obj/output_{i}_{j}", name=f"output_{i}_{j}") for j in range(4)
+            ]
+            children.append(node)
+        mock_connection.add_node(
+            MockHouNode(path="/obj/geo1", name="geo1", node_type="geo", children=children)
+        )
+        full = list_children("/obj/geo1", compact=False, limit=20, host="localhost", port=18811)
+        compact = list_children("/obj/geo1", compact=True, limit=20, host="localhost", port=18811)
+        full_size = len(json.dumps(full).encode())
+        compact_size = len(json.dumps(compact).encode())
+        assert compact_size <= full_size * 0.40
 
 
 class TestFindNodes:


### PR DESCRIPTION
## Summary
Completes the already-partial compact mode from bounded-response PR #11.

- compact children expose stable path/name/type plus packed display/render/bypassed flags
- full mode preserves input/output connection details
- pagination/count/cursor/next_offset and hard response cap remain intact
- regression fixture proves compact output is at least 60% smaller on a representative 20-node network with four inputs/outputs per node

## Tests
- 9 focused list_children tests green
- full suite: 648 passed, 12 skipped
- Ruff format/check green

Refs `houdini-mcp-16w`.