### PR TITLE
feat: integrate transaction runtime across mutating MCP wrappers (houdini-mcp-028)

### DIFF
--- a/houdini_mcp/server.py
+++ b/houdini_mcp/server.py
@@ -11,6 +11,8 @@ from starlette.responses import JSONResponse
 from . import tools
 from .connection import ensure_connected, get_connection_info, is_connected, ping
 from .tools._common import apply_response_cap
+from .transaction_runtime import run_transactional
+from .transaction_runtime import undo_last_agent_action as undo_last_transaction
 
 # Configure logging
 log_level = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -65,7 +67,13 @@ def create_node(
         - create_node("sphere", "/obj/geo1") -> Creates a sphere SOP inside geo1
         - create_node("cam", name="render_cam") -> Creates a camera named render_cam
     """
-    return tools.create_node(node_type, parent_path, name, HOUDINI_HOST, HOUDINI_PORT)
+    return run_transactional(
+        "create_node",
+        lambda: tools.create_node(node_type, parent_path, name, HOUDINI_HOST, HOUDINI_PORT),
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        affected_paths=[parent_path],
+    )
 
 
 @mcp.tool()
@@ -181,7 +189,13 @@ def set_parameter(
         - set_parameter("/obj/cam1", "tx", 10.0)
         - set_parameter("/obj/geo1", "t", [1.0, 2.0, 3.0])  # Vector param
     """
-    return tools.set_parameter(node_path, param_name, value, HOUDINI_HOST, HOUDINI_PORT)
+    return run_transactional(
+        "set_parameter",
+        lambda: tools.set_parameter(node_path, param_name, value, HOUDINI_HOST, HOUDINI_PORT),
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        affected_paths=[node_path],
+    )
 
 
 @mcp.tool()
@@ -245,7 +259,23 @@ def delete_node(node_path: str) -> dict[str, Any]:
 
     Warning: This operation cannot be undone via this API.
     """
-    return tools.delete_node(node_path, HOUDINI_HOST, HOUDINI_PORT)
+    return run_transactional(
+        "delete_node",
+        lambda: tools.delete_node(node_path, HOUDINI_HOST, HOUDINI_PORT),
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        affected_paths=[node_path],
+    )
+
+
+@mcp.tool()
+def undo_last_agent_action() -> dict[str, Any]:
+    """Undo the latest committed agent transaction if no human edit intervened.
+
+    Returns a structured conflict instead of undoing when the scene revision or
+    Houdini undo-stack top no longer matches the recorded agent transaction.
+    """
+    return undo_last_transaction(HOUDINI_HOST, HOUDINI_PORT)
 
 
 @mcp.tool()
@@ -814,8 +844,14 @@ def connect_nodes(
         connect_nodes("/obj/geo1/grid1", "/obj/geo1/noise1")
         connect_nodes("/obj/geo1/grid1", "/obj/geo1/merge1", dst_input_index=1)
     """
-    return tools.connect_nodes(
-        src_path, dst_path, dst_input_index, src_output_index, HOUDINI_HOST, HOUDINI_PORT
+    return run_transactional(
+        "connect_nodes",
+        lambda: tools.connect_nodes(
+            src_path, dst_path, dst_input_index, src_output_index, HOUDINI_HOST, HOUDINI_PORT
+        ),
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        affected_paths=[src_path, dst_path],
     )
 
 
@@ -835,7 +871,13 @@ def disconnect_node_input(node_path: str, input_index: int = 0) -> dict[str, Any
         disconnect_node_input("/obj/geo1/noise1")  # Disconnect first input
         disconnect_node_input("/obj/geo1/merge1", input_index=1)  # Disconnect second input
     """
-    return tools.disconnect_node_input(node_path, input_index, HOUDINI_HOST, HOUDINI_PORT)
+    return run_transactional(
+        "disconnect_node_input",
+        lambda: tools.disconnect_node_input(node_path, input_index, HOUDINI_HOST, HOUDINI_PORT),
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        affected_paths=[node_path],
+    )
 
 
 @mcp.tool()
@@ -865,7 +907,15 @@ def set_node_flags(
         set_node_flags("/obj/geo1/noise1", bypass=True)
         set_node_flags("/obj/geo1/mountain1", display=True)  # Only set display
     """
-    return tools.set_node_flags(node_path, display, render, bypass, HOUDINI_HOST, HOUDINI_PORT)
+    return run_transactional(
+        "set_node_flags",
+        lambda: tools.set_node_flags(
+            node_path, display, render, bypass, HOUDINI_HOST, HOUDINI_PORT
+        ),
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        affected_paths=[node_path],
+    )
 
 
 @mcp.tool()
@@ -887,7 +937,13 @@ def reorder_inputs(node_path: str, new_order: list[int]) -> dict[str, Any]:
         reorder_inputs("/obj/geo1/merge1", [1, 0, 2, 3])  # Swap first two inputs
         reorder_inputs("/obj/geo1/merge1", [2, 1, 0])  # Reverse three inputs
     """
-    return tools.reorder_inputs(node_path, new_order, HOUDINI_HOST, HOUDINI_PORT)
+    return run_transactional(
+        "reorder_inputs",
+        lambda: tools.reorder_inputs(node_path, new_order, HOUDINI_HOST, HOUDINI_PORT),
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        affected_paths=[node_path],
+    )
 
 
 @mcp.tool()
@@ -1089,8 +1145,14 @@ def create_material(
         create_material("principledshader", "red_metal",
                        parameters={"basecolor": [1, 0, 0], "metallic": 1.0})
     """
-    return tools.create_material(
-        material_type, name, parent_path, parameters, HOUDINI_HOST, HOUDINI_PORT
+    return run_transactional(
+        "create_material",
+        lambda: tools.create_material(
+            material_type, name, parent_path, parameters, HOUDINI_HOST, HOUDINI_PORT
+        ),
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        affected_paths=[parent_path],
     )
 
 
@@ -1118,7 +1180,15 @@ def assign_material(
         assign_material("/obj/geo1", "/mat/red_metal")
         assign_material("/obj/geo1", "/mat/gold", group="top_faces")
     """
-    return tools.assign_material(geometry_path, material_path, group, HOUDINI_HOST, HOUDINI_PORT)
+    return run_transactional(
+        "assign_material",
+        lambda: tools.assign_material(
+            geometry_path, material_path, group, HOUDINI_HOST, HOUDINI_PORT
+        ),
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        affected_paths=[geometry_path, material_path],
+    )
 
 
 @mcp.tool()
@@ -1169,8 +1239,14 @@ def layout_children(
         layout_children("/obj/geo1")
         layout_children("/obj/geo1", horizontal_spacing=3.0, vertical_spacing=2.0)
     """
-    return tools.layout_children(
-        node_path, horizontal_spacing, vertical_spacing, HOUDINI_HOST, HOUDINI_PORT
+    return run_transactional(
+        "layout_children",
+        lambda: tools.layout_children(
+            node_path, horizontal_spacing, vertical_spacing, HOUDINI_HOST, HOUDINI_PORT
+        ),
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        affected_paths=[node_path],
     )
 
 
@@ -1190,7 +1266,13 @@ def set_node_color(node_path: str, color: list[float]) -> dict[str, Any]:
         set_node_color("/obj/geo1/sphere1", [1, 0, 0])  # Red
         set_node_color("/obj/geo1/important", [1, 1, 0])  # Yellow
     """
-    return tools.set_node_color(node_path, color, HOUDINI_HOST, HOUDINI_PORT)
+    return run_transactional(
+        "set_node_color",
+        lambda: tools.set_node_color(node_path, color, HOUDINI_HOST, HOUDINI_PORT),
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        affected_paths=[node_path],
+    )
 
 
 @mcp.tool()
@@ -1210,7 +1292,13 @@ def set_node_position(node_path: str, x: float, y: float) -> dict[str, Any]:
         set_node_position("/obj/geo1/sphere1", 0, 0)
         set_node_position("/obj/geo1/sphere1", 5.0, -3.0)
     """
-    return tools.set_node_position(node_path, x, y, HOUDINI_HOST, HOUDINI_PORT)
+    return run_transactional(
+        "set_node_position",
+        lambda: tools.set_node_position(node_path, x, y, HOUDINI_HOST, HOUDINI_PORT),
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        affected_paths=[node_path],
+    )
 
 
 @mcp.tool()
@@ -1237,8 +1325,14 @@ def create_network_box(
     Examples:
         create_network_box("/obj/geo1", ["/obj/geo1/sphere1", "/obj/geo1/noise1"], "Deform")
     """
-    return tools.create_network_box(
-        parent_path, node_paths, label, color, HOUDINI_HOST, HOUDINI_PORT
+    return run_transactional(
+        "create_network_box",
+        lambda: tools.create_network_box(
+            parent_path, node_paths, label, color, HOUDINI_HOST, HOUDINI_PORT
+        ),
+        host=HOUDINI_HOST,
+        port=HOUDINI_PORT,
+        affected_paths=[parent_path, *node_paths],
     )
 
 

--- a/houdini_mcp/tools/transactions.py
+++ b/houdini_mcp/tools/transactions.py
@@ -102,12 +102,12 @@ class SceneTransaction(AbstractContextManager["SceneTransaction"]):
             self.manager._transaction_lock.release()
             raise RuntimeError("A scene transaction is already active")
         self.manager.active = self
-        self.record.before_revision = self.manager.revision()
-        if self.record.policy == TransactionPolicy.CHECKPOINT_REQUIRED:
-            self.record.checkpoint_path = str(
-                self.manager.create_checkpoint(self.record.transaction_id)
-            )
         try:
+            self.record.before_revision = self.manager.revision()
+            if self.record.policy == TransactionPolicy.CHECKPOINT_REQUIRED:
+                self.record.checkpoint_path = str(
+                    self.manager.create_checkpoint(self.record.transaction_id)
+                )
             if self.record.policy == TransactionPolicy.UNDOABLE:
                 self.record.undo_label = f"Houdini MCP {self.record.transaction_id}"
                 self._undo_context = self.manager.hou.undos.group(self.record.undo_label)

--- a/houdini_mcp/tools/transactions.py
+++ b/houdini_mcp/tools/transactions.py
@@ -233,24 +233,30 @@ class TransactionManager:
         return destination
 
     def undo_last_agent_action(self) -> TransactionRecord:
+        # Fast refusal avoids self-deadlock when called from inside the active
+        # transaction; the lock then makes revision/label check + undo atomic
+        # against concurrent commits.
         if self.active is not None:
             raise TransactionConflict("Cannot undo while a transaction is active")
-        committed = next(
-            (record for record in reversed(self.history) if record.result == "committed"), None
-        )
-        if committed is None:
-            raise TransactionConflict("No committed agent transaction to undo")
-        if committed.policy != TransactionPolicy.UNDOABLE:
-            raise TransactionConflict("Latest transaction is not Houdini-undoable")
-        if self.revision() != committed.after_revision:
-            raise TransactionConflict("Scene changed after the agent transaction")
-        labels = getattr(self.hou.undos, "undoLabels", lambda: [])()
-        if not labels or labels[0] != committed.undo_label:
-            raise TransactionConflict("Agent transaction is not the next undo operation")
-        self.hou.undos.performUndo()
-        committed.result = "undone"
-        self._append_audit(committed)
-        return committed
+        with self._transaction_lock:
+            if self.active is not None:
+                raise TransactionConflict("Cannot undo while a transaction is active")
+            committed = next(
+                (record for record in reversed(self.history) if record.result == "committed"), None
+            )
+            if committed is None:
+                raise TransactionConflict("No committed agent transaction to undo")
+            if committed.policy != TransactionPolicy.UNDOABLE:
+                raise TransactionConflict("Latest transaction is not Houdini-undoable")
+            if self.revision() != committed.after_revision:
+                raise TransactionConflict("Scene changed after the agent transaction")
+            labels = getattr(self.hou.undos, "undoLabels", lambda: [])()
+            if not labels or labels[0] != committed.undo_label:
+                raise TransactionConflict("Agent transaction is not the next undo operation")
+            self.hou.undos.performUndo()
+            committed.result = "undone"
+            self._append_audit(committed)
+            return committed
 
     def _finish(self, record: TransactionRecord) -> None:
         record.duration_ms = max(0, int((time.monotonic() - record.started_at) * 1000))

--- a/houdini_mcp/transaction_runtime.py
+++ b/houdini_mcp/transaction_runtime.py
@@ -1,0 +1,119 @@
+"""Server-side transaction runtime shared by mutating MCP wrappers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from .connection import ensure_connected
+from .tools._common import _serialize_scene_state
+from .tools.transactions import TransactionConflict, TransactionManager, TransactionRecord
+
+_manager: TransactionManager | None = None
+_manager_endpoint: tuple[str, int] | None = None
+
+
+def _scene_revision(hou: Any) -> str:
+    state = _serialize_scene_state(hou, "/obj")
+    payload = json.dumps(state, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def transaction_manager(host: str, port: int) -> TransactionManager:
+    global _manager, _manager_endpoint
+    endpoint = (host, port)
+    if _manager is None or _manager_endpoint != endpoint:
+        hou = ensure_connected(host, port)
+        checkpoint_dir = Path(
+            os.getenv(
+                "HOUDINI_MCP_CHECKPOINT_DIR",
+                str(Path(tempfile.gettempdir()) / "houdini-mcp-checkpoints"),
+            )
+        )
+        audit_path = Path(
+            os.getenv(
+                "HOUDINI_MCP_TRANSACTION_AUDIT",
+                str(Path(tempfile.gettempdir()) / "houdini-mcp-transactions.jsonl"),
+            )
+        )
+        _manager = TransactionManager(
+            hou,
+            lambda: _scene_revision(hou),
+            checkpoint_dir=checkpoint_dir,
+            audit_path=audit_path,
+        )
+        _manager_endpoint = endpoint
+    return _manager
+
+
+def _record_metadata(record: TransactionRecord) -> dict[str, Any]:
+    return {
+        "transaction_id": record.transaction_id,
+        "transaction_policy": record.policy.value,
+        "transaction_result": record.result,
+        "scene_revision_before": record.before_revision,
+        "scene_revision_after": record.after_revision,
+        "transaction_duration_ms": record.duration_ms,
+        "affected_paths": list(dict.fromkeys(record.affected_paths)),
+        "external_side_effects": record.side_effects,
+        "checkpoint_path": record.checkpoint_path,
+    }
+
+
+@contextmanager
+def transactional_tool(
+    tool: str,
+    *,
+    host: str,
+    port: int,
+    affected_paths: list[str] | None = None,
+    caller: str = "mcp-agent",
+    session_id: str = "mcp",
+) -> Iterator[dict[str, Any]]:
+    manager = transaction_manager(host, port)
+    with manager.begin(
+        [tool], affected_paths=affected_paths, caller=caller, session_id=session_id
+    ) as transaction:
+        result: dict[str, Any] = {}
+        yield result
+    result["_transaction"] = _record_metadata(transaction.record)
+
+
+def run_transactional(
+    tool: str,
+    operation: Any,
+    *,
+    host: str,
+    port: int,
+    affected_paths: list[str] | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any]
+    with transactional_tool(tool, host=host, port=port, affected_paths=affected_paths) as container:
+        result = operation()
+        container.update(result)
+    return container
+
+
+def undo_last_agent_action(host: str, port: int) -> dict[str, Any]:
+    try:
+        record = transaction_manager(host, port).undo_last_agent_action()
+        return {"status": "success", "_transaction": _record_metadata(record)}
+    except TransactionConflict as conflict:
+        return {
+            "status": "conflict",
+            "error": "transaction_conflict",
+            "message": str(conflict),
+        }
+
+
+def reset_transaction_runtime() -> None:
+    """Test hook; production retains one manager per configured endpoint."""
+    global _manager, _manager_endpoint
+    _manager = None
+    _manager_endpoint = None

--- a/houdini_mcp/transaction_runtime.py
+++ b/houdini_mcp/transaction_runtime.py
@@ -6,22 +6,66 @@ import hashlib
 import json
 import os
 import tempfile
+import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-from .connection import ensure_connected
-from .tools._common import _serialize_scene_state
+from .connection import HoudiniConnectionError, ensure_connected
+from .tools._common import CONNECTION_ERRORS, _json_safe_hou_value
 from .tools.transactions import TransactionConflict, TransactionManager, TransactionRecord
 
 _manager: TransactionManager | None = None
 _manager_endpoint: tuple[str, int] | None = None
+_manager_init_lock = threading.Lock()
+TRANSACTION_CONNECTION_ERRORS = (HoudiniConnectionError, *CONNECTION_ERRORS)
 
 
 def _scene_revision(hou: Any) -> str:
-    state = _serialize_scene_state(hou, "/obj")
-    payload = json.dumps(state, sort_keys=True, separators=(",", ":"), default=str)
+    """Hash topology plus mutable state across object and material contexts."""
+    rows: list[dict[str, Any]] = []
+    for root_path in ("/obj", "/mat", "/shop", "/stage", "/out"):
+        root = hou.node(root_path)
+        if root is None:
+            continue
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            children = list(node.children())
+            stack.extend(children)
+            parameters: dict[str, Any] = {}
+            for parm in getattr(node, "parms", lambda: [])():
+                try:
+                    parameters[parm.name()] = _json_safe_hou_value(parm.eval())
+                except Exception:
+                    continue
+            rows.append(
+                {
+                    "path": node.path(),
+                    "type": node.type().name(),
+                    "parameters": parameters,
+                    "inputs": [item.path() if item is not None else None for item in node.inputs()],
+                    "position": list(node.position())
+                    if callable(getattr(node, "position", None))
+                    else None,
+                    "color": list(node.color().rgb())
+                    if callable(getattr(node, "color", None)) and node.color() is not None
+                    else None,
+                    "flags": [
+                        bool(getattr(node, method)())
+                        if callable(getattr(node, method, None))
+                        else None
+                        for method in ("isDisplayFlagSet", "isRenderFlagSet", "isBypassed")
+                    ],
+                }
+            )
+    payload = json.dumps(
+        sorted(rows, key=lambda row: row["path"]),
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
@@ -29,26 +73,28 @@ def transaction_manager(host: str, port: int) -> TransactionManager:
     global _manager, _manager_endpoint
     endpoint = (host, port)
     if _manager is None or _manager_endpoint != endpoint:
-        hou = ensure_connected(host, port)
-        checkpoint_dir = Path(
-            os.getenv(
-                "HOUDINI_MCP_CHECKPOINT_DIR",
-                str(Path(tempfile.gettempdir()) / "houdini-mcp-checkpoints"),
-            )
-        )
-        audit_path = Path(
-            os.getenv(
-                "HOUDINI_MCP_TRANSACTION_AUDIT",
-                str(Path(tempfile.gettempdir()) / "houdini-mcp-transactions.jsonl"),
-            )
-        )
-        _manager = TransactionManager(
-            hou,
-            lambda: _scene_revision(hou),
-            checkpoint_dir=checkpoint_dir,
-            audit_path=audit_path,
-        )
-        _manager_endpoint = endpoint
+        with _manager_init_lock:
+            if _manager is None or _manager_endpoint != endpoint:
+                hou = ensure_connected(host, port)
+                checkpoint_dir = Path(
+                    os.getenv(
+                        "HOUDINI_MCP_CHECKPOINT_DIR",
+                        str(Path(tempfile.gettempdir()) / "houdini-mcp-checkpoints"),
+                    )
+                )
+                audit_path = Path(
+                    os.getenv(
+                        "HOUDINI_MCP_TRANSACTION_AUDIT",
+                        str(Path(tempfile.gettempdir()) / "houdini-mcp-transactions.jsonl"),
+                    )
+                )
+                _manager = TransactionManager(
+                    hou,
+                    lambda: _scene_revision(hou),
+                    checkpoint_dir=checkpoint_dir,
+                    audit_path=audit_path,
+                )
+                _manager_endpoint = endpoint
     return _manager
 
 
@@ -85,6 +131,12 @@ def transactional_tool(
     result["_transaction"] = _record_metadata(transaction.record)
 
 
+class ToolResultError(RuntimeError):
+    def __init__(self, result: dict[str, Any]):
+        super().__init__(str(result.get("message", "Tool returned an error")))
+        self.result = result
+
+
 def run_transactional(
     tool: str,
     operation: Any,
@@ -93,11 +145,19 @@ def run_transactional(
     port: int,
     affected_paths: list[str] | None = None,
 ) -> dict[str, Any]:
-    result: dict[str, Any]
-    with transactional_tool(tool, host=host, port=port, affected_paths=affected_paths) as container:
-        result = operation()
-        container.update(result)
-    return container
+    try:
+        with transactional_tool(
+            tool, host=host, port=port, affected_paths=affected_paths
+        ) as container:
+            result = operation()
+            if result.get("status") in {"error", "partial"}:
+                raise ToolResultError(result)
+            container.update(result)
+        return container
+    except ToolResultError as error:
+        return error.result
+    except TRANSACTION_CONNECTION_ERRORS as error:
+        return {"status": "error", "message": f"Houdini connection error: {error}"}
 
 
 def undo_last_agent_action(host: str, port: int) -> dict[str, Any]:

--- a/houdini_mcp/transaction_runtime.py
+++ b/houdini_mcp/transaction_runtime.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-from .connection import HoudiniConnectionError, ensure_connected
+from .connection import HoudiniConnectionError, ensure_connected, get_connection
 from .tools._common import CONNECTION_ERRORS, _json_safe_hou_value
 from .tools.transactions import TransactionConflict, TransactionManager, TransactionRecord
 
@@ -23,7 +23,59 @@ TRANSACTION_CONNECTION_ERRORS = (HoudiniConnectionError, *CONNECTION_ERRORS)
 
 
 def _scene_revision(hou: Any) -> str:
-    """Hash topology plus mutable state across object and material contexts."""
+    """Hash mutable scene state in one Houdini-side RPC when remote."""
+    connection = get_connection()
+    if connection is not None and callable(getattr(connection, "execute", None)):
+        code = """
+import hashlib as _hashlib
+import json as _json
+_rows = []
+for _root_path in ("/obj", "/mat", "/shop", "/stage", "/out"):
+    _root = hou.node(_root_path)
+    if _root is None:
+        continue
+    _stack = [_root]
+    while _stack:
+        _node = _stack.pop()
+        _stack.extend(_node.children())
+        _parms = {}
+        for _parm in _node.parms():
+            try:
+                _value = _parm.eval()
+                if isinstance(_value, (str, int, float, bool)) or _value is None:
+                    _parms[_parm.name()] = _value
+                elif isinstance(_value, (tuple, list)):
+                    _parms[_parm.name()] = list(_value)
+                else:
+                    _parms[_parm.name()] = str(_value)
+            except Exception:
+                pass
+        try:
+            _color = list(_node.color().rgb())
+        except Exception:
+            _color = None
+        try:
+            _position = list(_node.position())
+        except Exception:
+            _position = None
+        _rows.append({
+            "path": _node.path(),
+            "type": _node.type().name(),
+            "parameters": _parms,
+            "inputs": [_input.path() if _input is not None else None for _input in _node.inputs()],
+            "position": _position,
+            "color": _color,
+            "flags": [
+                bool(getattr(_node, _method)()) if callable(getattr(_node, _method, None)) else None
+                for _method in ("isDisplayFlagSet", "isRenderFlagSet", "isBypassed")
+            ],
+        })
+_payload = _json.dumps(sorted(_rows, key=lambda _row: _row["path"]), sort_keys=True, separators=(",", ":"), default=str)
+_mcp_scene_revision = _hashlib.sha256(_payload.encode("utf-8")).hexdigest()
+"""
+        connection.execute(code)
+        return str(connection.namespace["_mcp_scene_revision"])
+
     rows: list[dict[str, Any]] = []
     for root_path in ("/obj", "/mat", "/shop", "/stage", "/out"):
         root = hou.node(root_path)

--- a/houdini_mcp/transaction_runtime.py
+++ b/houdini_mcp/transaction_runtime.py
@@ -29,6 +29,7 @@ def _scene_revision(hou: Any) -> str:
         code = """
 import hashlib as _hashlib
 import json as _json
+import hou
 _rows = []
 for _root_path in ("/obj", "/mat", "/shop", "/stage", "/out"):
     _root = hou.node(_root_path)

--- a/tests/test_transaction_runtime.py
+++ b/tests/test_transaction_runtime.py
@@ -1,0 +1,96 @@
+"""MCP boundary integration tests for scene transactions."""
+
+from __future__ import annotations
+
+from houdini_mcp import server
+from houdini_mcp.transaction_runtime import reset_transaction_runtime
+
+
+def test_create_node_wrapper_returns_transaction_metadata(mock_connection, monkeypatch, tmp_path):
+    reset_transaction_runtime()
+    monkeypatch.setenv("HOUDINI_MCP_TRANSACTION_AUDIT", str(tmp_path / "audit.jsonl"))
+
+    result = server.create_node.fn("geo", name="transaction_geo")
+
+    assert result["status"] == "success"
+    assert result["node_path"] == "/obj/transaction_geo"
+    metadata = result["_transaction"]
+    assert metadata["transaction_id"]
+    assert metadata["transaction_policy"] == "undoable"
+    assert metadata["transaction_result"] == "committed"
+    assert metadata["affected_paths"] == ["/obj"]
+    assert metadata["scene_revision_before"] != metadata["scene_revision_after"]
+    assert mock_connection.undos.closed_groups == [f"Houdini MCP {metadata['transaction_id']}"]
+
+
+def test_parameter_wrapper_is_one_named_undo_action(mock_connection, monkeypatch, tmp_path):
+    from tests.conftest import MockHouNode
+
+    reset_transaction_runtime()
+    monkeypatch.setenv("HOUDINI_MCP_TRANSACTION_AUDIT", str(tmp_path / "audit.jsonl"))
+    node = MockHouNode(path="/obj/geo1", name="geo1", node_type="geo", params={"tx": 0.0})
+    mock_connection.add_node(node)
+
+    result = server.set_parameter.fn("/obj/geo1", "tx", 4.0)
+
+    assert result["status"] == "success"
+    assert node._params["tx"] == 4.0
+    assert len(mock_connection.undos.closed_groups) == 1
+    assert result["_transaction"]["affected_paths"] == ["/obj/geo1"]
+
+
+def test_undo_wrapper_refuses_intervening_scene_edit(mock_connection, monkeypatch, tmp_path):
+    reset_transaction_runtime()
+    monkeypatch.setenv("HOUDINI_MCP_TRANSACTION_AUDIT", str(tmp_path / "audit.jsonl"))
+    server.create_node.fn("geo", name="agent_geo")
+    # Simulate a human edit that changes both revision and undo stack top.
+    mock_connection.node("/obj").createNode("geo", "human_geo")
+    mock_connection.undos.closed_groups.append("Human edit")
+
+    result = server.undo_last_agent_action.fn()
+
+    assert result["status"] == "conflict"
+    assert result["error"] == "transaction_conflict"
+    assert mock_connection.undos.performed_undos == 0
+
+
+def test_undo_wrapper_succeeds_when_agent_action_is_stack_top(
+    mock_connection, monkeypatch, tmp_path
+):
+    reset_transaction_runtime()
+    monkeypatch.setenv("HOUDINI_MCP_TRANSACTION_AUDIT", str(tmp_path / "audit.jsonl"))
+    created = server.create_node.fn("geo", name="agent_geo")
+
+    result = server.undo_last_agent_action.fn()
+
+    assert result["status"] == "success"
+    assert result["_transaction"]["transaction_id"] == created["_transaction"]["transaction_id"]
+    assert result["_transaction"]["transaction_result"] == "undone"
+    assert mock_connection.undos.performed_undos == 1
+
+
+def test_core_mutating_wrappers_are_transactional():
+    """Static gate: core undoable wrappers may not bypass the runtime helper."""
+    import inspect
+
+    names = {
+        "create_node",
+        "delete_node",
+        "set_parameter",
+        "connect_nodes",
+        "disconnect_node_input",
+        "set_node_flags",
+        "reorder_inputs",
+        "create_material",
+        "assign_material",
+        "layout_children",
+        "set_node_color",
+        "set_node_position",
+        "create_network_box",
+    }
+    missing = {
+        name
+        for name in names
+        if "run_transactional" not in inspect.getsource(getattr(server, name).fn)
+    }
+    assert not missing, f"Mutating wrappers bypass transaction runtime: {sorted(missing)}"

--- a/tests/test_transaction_runtime.py
+++ b/tests/test_transaction_runtime.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from houdini_mcp import server
-from houdini_mcp.transaction_runtime import reset_transaction_runtime
+from houdini_mcp.transaction_runtime import reset_transaction_runtime, transaction_manager
 
 
 def call_tool(tool, *args, **kwargs):
@@ -83,6 +83,41 @@ def test_undo_wrapper_succeeds_when_agent_action_is_stack_top(
     assert result["_transaction"]["transaction_id"] == created["_transaction"]["transaction_id"]
     assert result["_transaction"]["transaction_result"] == "undone"
     assert mock_connection.undos.performed_undos == 1
+
+
+def test_error_result_is_not_recorded_as_committed(mock_connection, monkeypatch, tmp_path):
+    reset_transaction_runtime()
+    monkeypatch.setenv("HOUDINI_MCP_TRANSACTION_AUDIT", str(tmp_path / "audit.jsonl"))
+
+    result = call_tool(server.create_node, "geo", parent_path="/missing")
+
+    assert result["status"] == "error"
+    manager = transaction_manager("localhost", 18811)
+    assert manager.history[-1].result == "rolled_back"
+    assert not any(record.result == "committed" for record in manager.history)
+
+
+def test_material_parameter_change_affects_scene_revision(mock_connection, monkeypatch, tmp_path):
+    from tests.conftest import MockHouNode
+
+    reset_transaction_runtime()
+    monkeypatch.setenv("HOUDINI_MCP_TRANSACTION_AUDIT", str(tmp_path / "audit.jsonl"))
+    mat_context = MockHouNode(path="/mat", name="mat", node_type="matnet")
+    mock_connection.add_node(mat_context)
+
+    result = call_tool(
+        server.create_material,
+        "principledshader",
+        "revision_mat",
+        "/mat",
+        {"metallic": 1.0},
+    )
+
+    assert result["status"] == "success"
+    assert (
+        result["_transaction"]["scene_revision_before"]
+        != result["_transaction"]["scene_revision_after"]
+    )
 
 
 def test_checkpoint_entry_failure_releases_runtime_lock(mock_connection, monkeypatch, tmp_path):

--- a/tests/test_transaction_runtime.py
+++ b/tests/test_transaction_runtime.py
@@ -6,11 +6,27 @@ from houdini_mcp import server
 from houdini_mcp.transaction_runtime import reset_transaction_runtime
 
 
+def call_tool(tool, *args, **kwargs):
+    """Call through FastMCP's FunctionTool or the raw function used by tests.
+
+    The randomized full suite imports server under both the real decorator and a
+    monkeypatched identity decorator, so module-level wrappers legitimately have
+    either shape depending on test order.
+    """
+    return getattr(tool, "fn", tool)(*args, **kwargs)
+
+
+def tool_source(tool):
+    import inspect
+
+    return inspect.getsource(getattr(tool, "fn", tool))
+
+
 def test_create_node_wrapper_returns_transaction_metadata(mock_connection, monkeypatch, tmp_path):
     reset_transaction_runtime()
     monkeypatch.setenv("HOUDINI_MCP_TRANSACTION_AUDIT", str(tmp_path / "audit.jsonl"))
 
-    result = server.create_node.fn("geo", name="transaction_geo")
+    result = call_tool(server.create_node, "geo", name="transaction_geo")
 
     assert result["status"] == "success"
     assert result["node_path"] == "/obj/transaction_geo"
@@ -31,7 +47,7 @@ def test_parameter_wrapper_is_one_named_undo_action(mock_connection, monkeypatch
     node = MockHouNode(path="/obj/geo1", name="geo1", node_type="geo", params={"tx": 0.0})
     mock_connection.add_node(node)
 
-    result = server.set_parameter.fn("/obj/geo1", "tx", 4.0)
+    result = call_tool(server.set_parameter, "/obj/geo1", "tx", 4.0)
 
     assert result["status"] == "success"
     assert node._params["tx"] == 4.0
@@ -42,12 +58,12 @@ def test_parameter_wrapper_is_one_named_undo_action(mock_connection, monkeypatch
 def test_undo_wrapper_refuses_intervening_scene_edit(mock_connection, monkeypatch, tmp_path):
     reset_transaction_runtime()
     monkeypatch.setenv("HOUDINI_MCP_TRANSACTION_AUDIT", str(tmp_path / "audit.jsonl"))
-    server.create_node.fn("geo", name="agent_geo")
+    call_tool(server.create_node, "geo", name="agent_geo")
     # Simulate a human edit that changes both revision and undo stack top.
     mock_connection.node("/obj").createNode("geo", "human_geo")
     mock_connection.undos.closed_groups.append("Human edit")
 
-    result = server.undo_last_agent_action.fn()
+    result = call_tool(server.undo_last_agent_action)
 
     assert result["status"] == "conflict"
     assert result["error"] == "transaction_conflict"
@@ -59,9 +75,9 @@ def test_undo_wrapper_succeeds_when_agent_action_is_stack_top(
 ):
     reset_transaction_runtime()
     monkeypatch.setenv("HOUDINI_MCP_TRANSACTION_AUDIT", str(tmp_path / "audit.jsonl"))
-    created = server.create_node.fn("geo", name="agent_geo")
+    created = call_tool(server.create_node, "geo", name="agent_geo")
 
-    result = server.undo_last_agent_action.fn()
+    result = call_tool(server.undo_last_agent_action)
 
     assert result["status"] == "success"
     assert result["_transaction"]["transaction_id"] == created["_transaction"]["transaction_id"]
@@ -85,14 +101,12 @@ def test_checkpoint_entry_failure_releases_runtime_lock(mock_connection, monkeyp
 
     assert manager.active is None
     # If the transaction-wide lock leaked, this call blocks forever in CI.
-    result = server.create_node.fn("geo", name="after_checkpoint_failure")
+    result = call_tool(server.create_node, "geo", name="after_checkpoint_failure")
     assert result["status"] == "success"
 
 
 def test_core_mutating_wrappers_are_transactional():
     """Static gate: core undoable wrappers may not bypass the runtime helper."""
-    import inspect
-
     names = {
         "create_node",
         "delete_node",
@@ -109,8 +123,6 @@ def test_core_mutating_wrappers_are_transactional():
         "create_network_box",
     }
     missing = {
-        name
-        for name in names
-        if "run_transactional" not in inspect.getsource(getattr(server, name).fn)
+        name for name in names if "run_transactional" not in tool_source(getattr(server, name))
     }
     assert not missing, f"Mutating wrappers bypass transaction runtime: {sorted(missing)}"

--- a/tests/test_transaction_runtime.py
+++ b/tests/test_transaction_runtime.py
@@ -69,6 +69,26 @@ def test_undo_wrapper_succeeds_when_agent_action_is_stack_top(
     assert mock_connection.undos.performed_undos == 1
 
 
+def test_checkpoint_entry_failure_releases_runtime_lock(mock_connection, monkeypatch, tmp_path):
+    """A checkpoint failure must not deadlock the next MCP mutation."""
+    import pytest
+
+    from houdini_mcp.transaction_runtime import transaction_manager
+
+    reset_transaction_runtime()
+    monkeypatch.setenv("HOUDINI_MCP_TRANSACTION_AUDIT", str(tmp_path / "audit.jsonl"))
+    manager = transaction_manager("localhost", 18811)
+    mock_connection.hipFile.saveAndBackup.side_effect = RuntimeError("checkpoint failed")
+
+    with pytest.raises(RuntimeError, match="checkpoint failed"), manager.begin(["new_scene"]):
+        pass
+
+    assert manager.active is None
+    # If the transaction-wide lock leaked, this call blocks forever in CI.
+    result = server.create_node.fn("geo", name="after_checkpoint_failure")
+    assert result["status"] == "success"
+
+
 def test_core_mutating_wrappers_are_transactional():
     """Static gate: core undoable wrappers may not bypass the runtime helper."""
     import inspect


### PR DESCRIPTION
## Summary
Completes the MCP-boundary integration half of `houdini-mcp-028` on top of transaction foundation PR #17.

- endpoint-scoped `TransactionManager` initialized against the connected Houdini process
- deterministic scene revision hash from serialized `/obj` topology
- transaction metadata attached to mutation responses (id, policy/result, before/after revision, duration, affected paths, external effects/checkpoint)
- `undo_last_agent_action` MCP tool with structured conflict responses
- core node/parameter/wiring/material/layout mutations execute inside one named undo transaction per request
- static wrapper gate prevents those core mutators from bypassing `run_transactional`
- fake-hou integration proves metadata, one-action undo grouping, successful undo, and refusal after intervening human edit

## Tests
- 5 focused MCP-boundary tests green
- full suite: **668 passed, 12 skipped** (2 pre-existing background-listener warnings)
- Ruff format/check green

## Remaining acceptance
Main conversation still owns the opt-in live mini-sculpture create → hash/diff → one-action undo → replay check. Checkpoint/external mutators (`execute_code`, load/new/save, render/screenshot) remain governed by the foundation policy registry and need endpoint-specific live-path validation before `vzp.2` closes.

Refs `houdini-mcp-028`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scene-editing actions now run as tracked transactions with status, revision, affected-path, and timing information.
  * Added safer undo support for the most recent agent action, including conflict detection when intervening edits are detected.

* **Bug Fixes**
  * Failed scene changes are rolled back instead of being recorded as completed.
  * Improved recovery when checkpoint creation fails, allowing subsequent edits to continue normally.
  * Prevented concurrent transactions from interfering with undo operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->